### PR TITLE
Fix invalid message in YearHalf

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
@@ -51,7 +51,7 @@ public final class YearHalf implements Comparable<YearHalf> {
 		Month startMonth = switch (half) {
 			case 1 -> Month.JANUARY;
 			case 2 -> Month.JULY;
-			default -> throw new IllegalArgumentException("Invalid quarter: " + half);
+                        default -> throw new IllegalArgumentException("Invalid half: " + half);
 		};
 		return YearMonth.of(year, startMonth).atDay(1);
 	}
@@ -60,7 +60,7 @@ public final class YearHalf implements Comparable<YearHalf> {
 		Month month = switch (half) {
 			case 1 -> Month.JUNE;
 			case 2 -> Month.DECEMBER;
-			default -> throw new IllegalArgumentException("Invalid quarter: " + half);
+                        default -> throw new IllegalArgumentException("Invalid half: " + half);
 		};
 		return YearMonth.of(year, month).atEndOfMonth();
 	}


### PR DESCRIPTION
## Summary
- fix error message wording in `YearHalf.firstDay()` and `YearHalf.lastDay()`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c654629d8832496ef7e23a1b8d9c0