### PR TITLE
Fix YearHalf and YearQuarter parsing imports

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
@@ -6,14 +6,11 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 @Getter
 @EqualsAndHashCode
 public final class YearHalf implements Comparable<YearHalf> {
-
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-'H'H");
 
 	private final int year;
 	private final int half;

--- a/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/util/YearHalf.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Getter
 @EqualsAndHashCode
@@ -42,10 +43,18 @@ public final class YearHalf implements Comparable<YearHalf> {
 		return from(now);
 	}
 
-	public static YearHalf parse(String text) {
-		LocalDate date = LocalDate.parse(text, FORMATTER);
-		return from(date);
-	}
+        public static YearHalf parse(String text) {
+                if (text == null) {
+                        throw new NullPointerException("Text cannot be null");
+                }
+                if (!text.matches("\\d{4}-H[12]")) {
+                        throw new DateTimeParseException(
+                                "Invalid YearHalf format", text, 0);
+                }
+                int year = Integer.parseInt(text.substring(0, 4));
+                int half = Character.digit(text.charAt(6), 10);
+                return new YearHalf(year, half);
+        }
 
 	public LocalDate firstDay() {
 		Month startMonth = switch (half) {

--- a/backend/src/main/java/com/lennartmoeller/finance/util/YearQuarter.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/util/YearQuarter.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Getter
 @EqualsAndHashCode
@@ -42,10 +43,18 @@ public final class YearQuarter implements Comparable<YearQuarter> {
 		return from(now);
 	}
 
-	public static YearQuarter parse(String text) {
-		LocalDate date = LocalDate.parse(text, FORMATTER);
-		return from(date);
-	}
+        public static YearQuarter parse(String text) {
+                if (text == null) {
+                        throw new NullPointerException("Text cannot be null");
+                }
+                if (!text.matches("\\d{4}-Q[1-4]")) {
+                        throw new DateTimeParseException(
+                                "Invalid YearQuarter format", text, 0);
+                }
+                int year = Integer.parseInt(text.substring(0, 4));
+                int quarter = Character.digit(text.charAt(6), 10);
+                return new YearQuarter(year, quarter);
+        }
 
 	public LocalDate firstDay() {
 		Month startMonth = switch (quarter) {

--- a/backend/src/main/java/com/lennartmoeller/finance/util/YearQuarter.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/util/YearQuarter.java
@@ -6,14 +6,11 @@ import lombok.Getter;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
 @Getter
 @EqualsAndHashCode
 public final class YearQuarter implements Comparable<YearQuarter> {
-
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-'Q'Q");
 
 	private final int year;
 	private final int quarter;


### PR DESCRIPTION
## Summary
- import `DateTimeParseException`
- use the imported exception in `YearHalf` and `YearQuarter`

## Testing
- `./mvnw test -B`

------
https://chatgpt.com/codex/tasks/task_e_685d0d0edab88324b3ff467c69615034