### PR TITLE
Add unit tests for service layer

### DIFF
--- a/backend/src/test/java/com/lennartmoeller/finance/service/AccountBalanceServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/AccountBalanceServiceTest.java
@@ -1,0 +1,60 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.AccountBalanceDTO;
+import com.lennartmoeller.finance.projection.AccountBalanceProjection;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class AccountBalanceServiceTest {
+
+    private AccountRepository accountRepository;
+    private AccountBalanceService service;
+
+    @BeforeEach
+    void setUp() {
+        accountRepository = mock(AccountRepository.class);
+        service = new AccountBalanceService(accountRepository);
+    }
+
+    @Test
+    void testFindAllSortedAndMapped() {
+        AccountBalanceProjection p1 = new SimpleProjection(1L, 100L, 5L);
+        AccountBalanceProjection p2 = new SimpleProjection(2L, 200L, 10L);
+        AccountBalanceProjection p3 = new SimpleProjection(3L, 50L, 1L);
+        when(accountRepository.getAccountBalances()).thenReturn(List.of(p1, p2, p3));
+
+        List<AccountBalanceDTO> result = service.findAll();
+
+        // should be sorted descending by transactionCount
+        assertEquals(3, result.size());
+        assertEquals(2L, result.get(0).getAccountId());
+        assertEquals(200L, result.get(0).getBalance());
+        assertEquals(1L, result.get(1).getAccountId());
+        assertEquals(100L, result.get(1).getBalance());
+        assertEquals(3L, result.get(2).getAccountId());
+        assertEquals(50L, result.get(2).getBalance());
+    }
+
+    private static class SimpleProjection implements AccountBalanceProjection {
+        private final Long accountId;
+        private final Long balance;
+        private final Long transactionCount;
+        SimpleProjection(Long accountId, Long balance, Long transactionCount) {
+            this.accountId = accountId;
+            this.balance = balance;
+            this.transactionCount = transactionCount;
+        }
+        @Override
+        public Long getAccountId() { return accountId; }
+        @Override
+        public Long getBalance() { return balance; }
+        @Override
+        public Long getTransactionCount() { return transactionCount; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/AccountServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/AccountServiceTest.java
@@ -1,0 +1,96 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.AccountDTO;
+import com.lennartmoeller.finance.mapper.AccountMapper;
+import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AccountServiceTest {
+
+    private AccountRepository accountRepository;
+    private AccountMapper accountMapper;
+    private AccountService accountService;
+
+    @BeforeEach
+    void setUp() {
+        accountRepository = mock(AccountRepository.class);
+        accountMapper = mock(AccountMapper.class);
+        accountService = new AccountService(accountRepository, accountMapper);
+    }
+
+    @Test
+    void testFindAllSorted() {
+        Account a1 = new Account();
+        a1.setId(1L);
+        a1.setLabel("B");
+        Account a2 = new Account();
+        a2.setId(2L);
+        a2.setLabel("A");
+        when(accountRepository.findAll()).thenReturn(List.of(a1, a2));
+
+        AccountDTO d1 = new AccountDTO();
+        d1.setLabel("B");
+        AccountDTO d2 = new AccountDTO();
+        d2.setLabel("A");
+        when(accountMapper.toDto(a1)).thenReturn(d1);
+        when(accountMapper.toDto(a2)).thenReturn(d2);
+
+        List<AccountDTO> result = accountService.findAll();
+
+        assertEquals(List.of(d2, d1), result); // sorted by label
+    }
+
+    @Test
+    void testFindByIdFound() {
+        Account account = new Account();
+        account.setId(5L);
+        AccountDTO dto = new AccountDTO();
+        when(accountRepository.findById(5L)).thenReturn(Optional.of(account));
+        when(accountMapper.toDto(account)).thenReturn(dto);
+
+        Optional<AccountDTO> result = accountService.findById(5L);
+
+        assertTrue(result.isPresent());
+        assertEquals(dto, result.get());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(accountRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<AccountDTO> result = accountService.findById(99L);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(accountMapper);
+    }
+
+    @Test
+    void testSave() {
+        AccountDTO dtoIn = new AccountDTO();
+        Account entity = new Account();
+        Account saved = new Account();
+        AccountDTO dtoOut = new AccountDTO();
+
+        when(accountMapper.toEntity(dtoIn)).thenReturn(entity);
+        when(accountRepository.save(entity)).thenReturn(saved);
+        when(accountMapper.toDto(saved)).thenReturn(dtoOut);
+
+        AccountDTO result = accountService.save(dtoIn);
+
+        assertEquals(dtoOut, result);
+    }
+
+    @Test
+    void testDeleteById() {
+        accountService.deleteById(42L);
+        verify(accountRepository).deleteById(42L);
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/DailyBalanceStatsServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/DailyBalanceStatsServiceTest.java
@@ -1,0 +1,145 @@
+
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.DailySavingStatsDTO;
+import com.lennartmoeller.finance.dto.StatsMetricDTO;
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.CategorySmoothType;
+import com.lennartmoeller.finance.model.TransactionType;
+import com.lennartmoeller.finance.projection.DailyBalanceProjection;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import com.lennartmoeller.finance.util.DateRange;
+import com.lennartmoeller.finance.util.smoother.SmootherDaily;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DailyBalanceStatsServiceTest {
+
+    private AccountRepository accountRepository;
+    private TransactionRepository transactionRepository;
+    private DailyBalanceStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        accountRepository = mock(AccountRepository.class);
+        transactionRepository = mock(TransactionRepository.class);
+        service = new DailyBalanceStatsService(accountRepository, transactionRepository);
+    }
+
+    @Test
+    void testGetStats() {
+        LocalDate now = LocalDate.now();
+        LocalDate first = now.withDayOfMonth(1);
+
+        Category incomeCat = new Category();
+        incomeCat.setTransactionType(TransactionType.INCOME);
+        incomeCat.setSmoothType(CategorySmoothType.DAILY);
+        Category expenseCat = new Category();
+        expenseCat.setTransactionType(TransactionType.EXPENSE);
+        expenseCat.setSmoothType(CategorySmoothType.DAILY);
+        Category investCat = new Category();
+        investCat.setTransactionType(TransactionType.INVESTMENT);
+        investCat.setSmoothType(CategorySmoothType.DAILY);
+
+        List<DailyBalanceProjection> projections = List.of(
+                new SimpleProjection(first, incomeCat, 50L),
+                new SimpleProjection(first, expenseCat, -20L),
+                new SimpleProjection(first.plusDays(1), investCat, 30L)
+        );
+        when(transactionRepository.getDailyBalances()).thenReturn(projections);
+        when(accountRepository.getSummedStartBalance()).thenReturn(1000L);
+
+        List<DailySavingStatsDTO> result = service.getStats();
+
+        // compute expected using same algorithm
+        Map<TransactionType, SmootherDaily> smoothers = Map.of(
+                TransactionType.INCOME, new SmootherDaily(),
+                TransactionType.EXPENSE, new SmootherDaily(),
+                TransactionType.INVESTMENT, new SmootherDaily()
+        );
+        projections.forEach(p -> smoothers.get(p.getCategory().getTransactionType()).add(
+                p.getDate(), p.getCategory().getSmoothType(), p.getBalance()
+        ));
+
+        DateRange range = new DateRange(first, now);
+        List<DailySavingStatsDTO> expected = new ArrayList<>();
+        StatsMetricDTO balance = new StatsMetricDTO();
+        balance.setRaw(1000);
+        balance.setSmoothed(1000);
+        StatsMetricDTO target = new StatsMetricDTO();
+        target.setRaw(1000);
+        target.setSmoothed(1000);
+        for (LocalDate d : range.createDateStream().toList()) {
+            StatsMetricDTO inc = smoothers.get(TransactionType.INCOME).get(d);
+            StatsMetricDTO exp = smoothers.get(TransactionType.EXPENSE).get(d);
+            StatsMetricDTO inv = smoothers.get(TransactionType.INVESTMENT).get(d);
+            balance = StatsMetricDTO.add(List.of(balance, inc, inv, exp));
+            target = StatsMetricDTO.add(List.of(target, StatsMetricDTO.multiply(inc, 0.2), inv));
+            DailySavingStatsDTO dto = new DailySavingStatsDTO();
+            dto.setDate(d);
+            dto.setBalance(balance);
+            dto.setTarget(target);
+            expected.add(dto);
+        }
+
+        assertEquals(expected.size(), result.size());
+        for (int i = 0; i < expected.size(); i++) {
+            DailySavingStatsDTO expDto = expected.get(i);
+            DailySavingStatsDTO actDto = result.get(i);
+            assertEquals(expDto.getDate(), actDto.getDate());
+            assertEquals(expDto.getBalance().getRaw(), actDto.getBalance().getRaw(), 0.0001);
+            assertEquals(expDto.getTarget().getRaw(), actDto.getTarget().getRaw(), 0.0001);
+        }
+    }
+
+    @Test
+    void testGetMonthlyMeanBalances() {
+        DailyBalanceStatsService spy = spy(new DailyBalanceStatsService(accountRepository, transactionRepository));
+        DailySavingStatsDTO d1 = new DailySavingStatsDTO();
+        d1.setDate(LocalDate.of(2021,1,1));
+        StatsMetricDTO s1 = new StatsMetricDTO();
+        s1.setRaw(10);
+        s1.setSmoothed(20);
+        d1.setBalance(s1);
+        DailySavingStatsDTO d2 = new DailySavingStatsDTO();
+        d2.setDate(LocalDate.of(2021,1,2));
+        StatsMetricDTO s2 = new StatsMetricDTO();
+        s2.setRaw(30);
+        s2.setSmoothed(40);
+        d2.setBalance(s2);
+        doReturn(List.of(d1, d2)).when(spy).getStats();
+
+        Map<YearMonth, StatsMetricDTO> result = spy.getMonthlyMeanBalances();
+
+        StatsMetricDTO mean = result.get(YearMonth.of(2021,1));
+        assertEquals(20.0, mean.getRaw());
+        assertEquals(30.0, mean.getSmoothed());
+    }
+
+    private static class SimpleProjection implements DailyBalanceProjection {
+        private final LocalDate date;
+        private final Category category;
+        private final Long balance;
+        SimpleProjection(LocalDate date, Category category, Long balance) {
+            this.date = date;
+            this.category = category;
+            this.balance = balance;
+        }
+        @Override
+        public LocalDate getDate() { return date; }
+        @Override
+        public Category getCategory() { return category; }
+        @Override
+        public Long getBalance() { return balance; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/MonthlyCategoryBalanceStatsServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/MonthlyCategoryBalanceStatsServiceTest.java
@@ -1,0 +1,118 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.CategoryDTO;
+import com.lennartmoeller.finance.dto.MonthlyCategoryStatsDTO;
+import com.lennartmoeller.finance.dto.RowStatsDTO;
+import com.lennartmoeller.finance.mapper.CategoryMapper;
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.CategorySmoothType;
+import com.lennartmoeller.finance.model.TransactionType;
+import com.lennartmoeller.finance.projection.DailyBalanceProjection;
+import com.lennartmoeller.finance.repository.CategoryRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MonthlyCategoryBalanceStatsServiceTest {
+
+    private CategoryMapper categoryMapper;
+    private CategoryRepository categoryRepository;
+    private TransactionRepository transactionRepository;
+    private MonthlyCategoryBalanceStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        categoryMapper = mock(CategoryMapper.class);
+        categoryRepository = mock(CategoryRepository.class);
+        transactionRepository = mock(TransactionRepository.class);
+        service = new MonthlyCategoryBalanceStatsService(categoryMapper, categoryRepository, transactionRepository);
+    }
+
+    @Test
+    void testGetStatsEmpty() {
+        when(transactionRepository.getDailyBalances()).thenReturn(List.of());
+
+        MonthlyCategoryStatsDTO dto = service.getStats();
+
+        assertNotNull(dto.getStats());
+        assertTrue(dto.getStats().values().stream().allMatch(s -> s.getCategoryStats().isEmpty()));
+    }
+
+    @Test
+    void testGetStatsWithData() {
+        LocalDate start = LocalDate.now().withDayOfMonth(1);
+        Category expParent = new Category();
+        expParent.setId(1L);
+        expParent.setTransactionType(TransactionType.EXPENSE);
+        expParent.setSmoothType(CategorySmoothType.DAILY);
+        Category expChild = new Category();
+        expChild.setId(2L);
+        expChild.setParent(expParent);
+        expChild.setTransactionType(TransactionType.EXPENSE);
+        expChild.setSmoothType(CategorySmoothType.DAILY);
+        expParent.setTargets(List.of());
+        expChild.setTargets(List.of());
+        Category incomeCat = new Category();
+        incomeCat.setId(3L);
+        incomeCat.setTransactionType(TransactionType.INCOME);
+        incomeCat.setSmoothType(CategorySmoothType.DAILY);
+        incomeCat.setTargets(List.of());
+
+        when(categoryRepository.findAll()).thenReturn(List.of(expParent, expChild, incomeCat));
+
+        CategoryDTO expParentDto = new CategoryDTO();
+        CategoryDTO expChildDto = new CategoryDTO();
+        CategoryDTO incomeDto = new CategoryDTO();
+        when(categoryMapper.toDto(expParent)).thenReturn(expParentDto);
+        when(categoryMapper.toDto(expChild)).thenReturn(expChildDto);
+        when(categoryMapper.toDto(incomeCat)).thenReturn(incomeDto);
+
+        List<DailyBalanceProjection> projections = List.of(
+                new SimpleProjection(start, expChild, -10L),
+                new SimpleProjection(start, incomeCat, 20L),
+                new SimpleProjection(start.plusDays(1), incomeCat, 30L)
+        );
+        when(transactionRepository.getDailyBalances()).thenReturn(projections);
+
+        MonthlyCategoryStatsDTO result = service.getStats();
+
+        YearMonth month = YearMonth.from(start);
+        // income surplus should sum to 50
+        RowStatsDTO incomeTotal = result.getStats().get(TransactionType.INCOME).getTotalStats();
+        assertEquals(50.0, incomeTotal.getMonthly().get(month).getSurplus().getRaw());
+        // expense parent should aggregate child (-10)
+        RowStatsDTO expenseTotal = result.getStats().get(TransactionType.EXPENSE).getTotalStats();
+        assertEquals(-10.0, expenseTotal.getMonthly().get(month).getSurplus().getRaw());
+        // investment stats should be empty but still have month entry
+        RowStatsDTO investTotal = result.getStats().get(TransactionType.INVESTMENT).getTotalStats();
+        assertEquals(0.0, investTotal.getMonthly().get(month).getSurplus().getRaw());
+
+        assertEquals(start, result.getStartDate());
+        assertEquals(LocalDate.now(), result.getEndDate());
+    }
+
+    private static class SimpleProjection implements DailyBalanceProjection {
+        private final LocalDate date;
+        private final Category category;
+        private final Long balance;
+        SimpleProjection(LocalDate date, Category category, Long balance) {
+            this.date = date;
+            this.category = category;
+            this.balance = balance;
+        }
+        @Override
+        public LocalDate getDate() { return date; }
+        @Override
+        public Category getCategory() { return category; }
+        @Override
+        public Long getBalance() { return balance; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/MonthlySavingStatsServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/MonthlySavingStatsServiceTest.java
@@ -1,0 +1,143 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.*;
+import com.lennartmoeller.finance.model.InflationRate;
+import com.lennartmoeller.finance.model.TransactionType;
+import com.lennartmoeller.finance.projection.MonthlyDepositsProjection;
+import com.lennartmoeller.finance.repository.InflationRateRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import com.lennartmoeller.finance.util.DateRange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MonthlySavingStatsServiceTest {
+
+    private DailyBalanceStatsService dailyBalanceStatsService;
+    private MonthlyCategoryBalanceStatsService monthlyCategoryBalanceStatsService;
+    private InflationRateRepository inflationRateRepository;
+    private TransactionRepository transactionRepository;
+    private MonthlySavingStatsService service;
+
+    @BeforeEach
+    void setUp() {
+        dailyBalanceStatsService = mock(DailyBalanceStatsService.class);
+        monthlyCategoryBalanceStatsService = mock(MonthlyCategoryBalanceStatsService.class);
+        inflationRateRepository = mock(InflationRateRepository.class);
+        transactionRepository = mock(TransactionRepository.class);
+        service = new MonthlySavingStatsService(dailyBalanceStatsService, monthlyCategoryBalanceStatsService,
+                inflationRateRepository, transactionRepository);
+    }
+
+    @Test
+    void testGetStats() {
+        YearMonth ym1 = YearMonth.of(2021,1);
+        YearMonth ym2 = YearMonth.of(2021,2);
+
+        Map<YearMonth, StatsMetricDTO> meanBalances = Map.of(
+                ym1, metric(1000),
+                ym2, metric(1100)
+        );
+        when(dailyBalanceStatsService.getMonthlyMeanBalances()).thenReturn(meanBalances);
+
+        DateRange range = new DateRange(ym1, ym2);
+        MonthlyCategoryStatsDTO categoryStats = new MonthlyCategoryStatsDTO();
+        categoryStats.setStartDate(range.getStartDate());
+        categoryStats.setEndDate(range.getEndDate());
+
+        CategoryStatsDTO incomeCategory = new CategoryStatsDTO();
+        incomeCategory.setStats(new RowStatsDTO(Map.of(
+                ym1, cell(metric(100)),
+                ym2, cell(metric(120))
+        )));
+        TransactionTypeStatsDTO incomeStats = new TransactionTypeStatsDTO(List.of(incomeCategory), range);
+
+        CategoryStatsDTO investCategory = new CategoryStatsDTO();
+        investCategory.setStats(new RowStatsDTO(Map.of(
+                ym1, cell(metric(20)),
+                ym2, cell(metric(30))
+        )));
+        TransactionTypeStatsDTO investStats = new TransactionTypeStatsDTO(List.of(investCategory), range);
+
+        CategoryStatsDTO expenseCategory = new CategoryStatsDTO();
+        expenseCategory.setStats(new RowStatsDTO(Map.of(
+                ym1, cell(metric(-50)),
+                ym2, cell(metric(-80))
+        )));
+        TransactionTypeStatsDTO expenseStats = new TransactionTypeStatsDTO(List.of(expenseCategory), range);
+
+        categoryStats.setStats(Map.of(
+                TransactionType.INCOME, incomeStats,
+                TransactionType.INVESTMENT, investStats,
+                TransactionType.EXPENSE, expenseStats
+        ));
+        when(monthlyCategoryBalanceStatsService.getStats()).thenReturn(categoryStats);
+
+        InflationRate r1 = new InflationRate();
+        r1.setYearMonth(ym1);
+        r1.setRate(0.02); // 2%
+        InflationRate r2 = new InflationRate();
+        r2.setYearMonth(ym2);
+        r2.setRate(0.03); // 3%
+        when(inflationRateRepository.findAll()).thenReturn(List.of(r1, r2));
+
+        MonthlyDepositsProjection p1 = new SimpleDeposit("2021-01", 500L);
+        MonthlyDepositsProjection p2 = new SimpleDeposit("2021-02", 600L);
+        when(transactionRepository.getMonthlyDeposits()).thenReturn(List.of(p1, p2));
+
+        List<MonthlySavingStatsDTO> result = service.getStats();
+
+        MonthlySavingStatsDTO dto1 = result.get(0);
+        assertEquals(ym1, dto1.getYearMonth());
+        assertEquals(70.0, dto1.getBalanceChange().getRaw()); // income(100)+invest(20)+expense(-50)
+        assertEquals(40.0, dto1.getBalanceChangeTarget().getRaw()); // income*0.2 + invest
+        assertEquals(500L, dto1.getDeposits());
+        assertEquals(20.0, dto1.getDepositsTarget());
+        assertEquals(-20.0, dto1.getInflationLoss()); // 1000 * -0.02
+        assertEquals(20.0, dto1.getInvestmentRevenue());
+
+        MonthlySavingStatsDTO dto2 = result.get(1);
+        assertEquals(ym2, dto2.getYearMonth());
+        assertEquals(70.0, dto2.getBalanceChange().getRaw());
+        assertEquals(54.0, dto2.getBalanceChangeTarget().getRaw());
+        assertEquals(600L, dto2.getDeposits());
+        assertEquals(24.0, dto2.getDepositsTarget());
+        assertEquals(-33.0, dto2.getInflationLoss()); // 1100 * -0.03
+        assertEquals(30.0, dto2.getInvestmentRevenue());
+    }
+
+    private static StatsMetricDTO metric(double raw) {
+        StatsMetricDTO dto = new StatsMetricDTO();
+        dto.setRaw(raw);
+        dto.setSmoothed(raw);
+        return dto;
+    }
+
+    private static CellStatsDTO cell(StatsMetricDTO m) {
+        CellStatsDTO c = new CellStatsDTO();
+        c.setSurplus(m);
+        c.setTarget(0.0);
+        PerformanceDTO perf = new PerformanceDTO();
+        c.setPerformance(perf);
+        return c;
+    }
+
+    private static class SimpleDeposit implements MonthlyDepositsProjection {
+        private final String yearMonth;
+        private final Long deposits;
+        SimpleDeposit(String yearMonth, Long deposits) {
+            this.yearMonth = yearMonth;
+            this.deposits = deposits;
+        }
+        @Override
+        public String getYearMonth() { return yearMonth; }
+        @Override
+        public Long getDeposits() { return deposits; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
@@ -1,0 +1,120 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.TransactionDTO;
+import com.lennartmoeller.finance.mapper.TransactionMapper;
+import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TransactionServiceTest {
+
+    private CategoryService categoryService;
+    private TransactionRepository transactionRepository;
+    private TransactionMapper transactionMapper;
+    private TransactionService service;
+
+    @BeforeEach
+    void setUp() {
+        categoryService = mock(CategoryService.class);
+        transactionRepository = mock(TransactionRepository.class);
+        transactionMapper = mock(TransactionMapper.class);
+        service = new TransactionService(categoryService, transactionRepository, transactionMapper);
+    }
+
+    @Test
+    void testFindFiltered() {
+        List<Long> accountIds = List.of(1L);
+        List<Long> categoryIds = List.of(2L);
+        List<Long> extendedCategoryIds = List.of(2L, 3L);
+        List<YearMonth> months = List.of(YearMonth.of(2021, 1));
+        List<String> monthStrings = List.of("2021-01");
+        when(categoryService.collectChildCategoryIdsRecursively(categoryIds)).thenReturn(extendedCategoryIds);
+
+        Transaction t1 = new Transaction();
+        t1.setId(2L);
+        t1.setDate(LocalDate.of(2021, 1, 10));
+        Transaction t2 = new Transaction();
+        t2.setId(1L);
+        t2.setDate(LocalDate.of(2021, 1, 10));
+        Transaction t3 = new Transaction();
+        t3.setId(3L);
+        t3.setDate(LocalDate.of(2021, 1, 11));
+        when(transactionRepository.findFiltered(accountIds, extendedCategoryIds, monthStrings)).thenReturn(List.of(t1, t2, t3));
+
+        TransactionDTO d1 = new TransactionDTO();
+        TransactionDTO d2 = new TransactionDTO();
+        TransactionDTO d3 = new TransactionDTO();
+        when(transactionMapper.toDto(t1)).thenReturn(d1);
+        when(transactionMapper.toDto(t2)).thenReturn(d2);
+        when(transactionMapper.toDto(t3)).thenReturn(d3);
+
+        List<TransactionDTO> result = service.findFiltered(accountIds, categoryIds, months);
+
+        assertEquals(List.of(d2, d1, d3), result); // sorted by date then id
+        verify(transactionRepository).findFiltered(accountIds, extendedCategoryIds, monthStrings);
+    }
+
+    @Test
+    void testFindFilteredNullParameters() {
+        when(categoryService.collectChildCategoryIdsRecursively(null)).thenReturn(null);
+        when(transactionRepository.findFiltered(null, null, null)).thenReturn(List.of());
+
+        List<TransactionDTO> result = service.findFiltered(null, null, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testFindByIdFound() {
+        Transaction t = new Transaction();
+        t.setId(7L);
+        TransactionDTO dto = new TransactionDTO();
+        when(transactionRepository.findById(7L)).thenReturn(Optional.of(t));
+        when(transactionMapper.toDto(t)).thenReturn(dto);
+
+        Optional<TransactionDTO> result = service.findById(7L);
+
+        assertTrue(result.isPresent());
+        assertEquals(dto, result.get());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(transactionRepository.findById(8L)).thenReturn(Optional.empty());
+
+        Optional<TransactionDTO> result = service.findById(8L);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testSave() {
+        TransactionDTO dtoIn = new TransactionDTO();
+        Transaction entity = new Transaction();
+        Transaction saved = new Transaction();
+        TransactionDTO dtoOut = new TransactionDTO();
+
+        when(transactionMapper.toEntity(dtoIn)).thenReturn(entity);
+        when(transactionRepository.save(entity)).thenReturn(saved);
+        when(transactionMapper.toDto(saved)).thenReturn(dtoOut);
+
+        TransactionDTO result = service.save(dtoIn);
+
+        assertEquals(dtoOut, result);
+    }
+
+    @Test
+    void testDeleteById() {
+        service.deleteById(11L);
+        verify(transactionRepository).deleteById(11L);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for AccountBalanceService
- add tests for AccountService
- add tests for DailyBalanceStatsService
- add tests for MonthlyCategoryBalanceStatsService
- add tests for MonthlySavingStatsService
- add tests for TransactionService

## Testing
- `./mvnw test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_685d2ab09da083249dd225dc5348ff9a