### PR TITLE
Add comprehensive mapper unit tests

### DIFF
--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
@@ -1,0 +1,38 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.AccountDTO;
+import com.lennartmoeller.finance.model.Account;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountMapperTest {
+
+    private final AccountMapper mapper = new AccountMapperImpl();
+
+    @Test
+    void testToDtoAndBack() {
+        Account account = new Account();
+        account.setId(1L);
+        account.setLabel("Checking");
+        account.setStartBalance(500L);
+        account.setActive(false);
+        account.setDeposits(true);
+
+        AccountDTO dto = mapper.toDto(account);
+        assertNotNull(dto);
+        assertEquals(account.getId(), dto.getId());
+        assertEquals(account.getLabel(), dto.getLabel());
+        assertEquals(account.getStartBalance(), dto.getStartBalance());
+        assertEquals(account.getActive(), dto.getActive());
+
+        Account entity = mapper.toEntity(dto);
+        assertNotNull(entity);
+        assertEquals(account.getId(), entity.getId());
+        assertEquals(account.getLabel(), entity.getLabel());
+        assertEquals(account.getStartBalance(), entity.getStartBalance());
+        assertEquals(account.getActive(), entity.getActive());
+        // deposits is not part of the DTO and should remain default (false)
+        assertFalse(entity.getDeposits());
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/CategoryMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/CategoryMapperTest.java
@@ -1,0 +1,116 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.CategoryDTO;
+import com.lennartmoeller.finance.dto.TargetDTO;
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.CategorySmoothType;
+import com.lennartmoeller.finance.model.Target;
+import com.lennartmoeller.finance.model.TransactionType;
+import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CategoryMapperTest {
+
+    private static void inject(Object target, Class<?> owner, String fieldName, Object value) throws Exception {
+        Field f = owner.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    @Test
+    void testToDto() throws Exception {
+        Category parent = new Category();
+        parent.setId(1L);
+
+        Category child = new Category();
+        child.setId(2L);
+        child.setParent(parent);
+        child.setLabel("Food");
+        child.setTransactionType(TransactionType.EXPENSE);
+        child.setSmoothType(CategorySmoothType.MONTHLY);
+        child.setIcon("icon");
+
+        Target target = new Target();
+        target.setId(3L);
+        target.setCategory(child);
+        target.setAmount(50L);
+        child.setTargets(List.of(target));
+
+        TargetMapperImpl targetMapper = new TargetMapperImpl();
+        CategoryMapperImpl mapper = new CategoryMapperImpl();
+        inject(mapper, CategoryMapperImpl.class, "targetMapper", targetMapper);
+
+        CategoryDTO dto = mapper.toDto(child);
+
+        assertEquals(child.getId(), dto.getId());
+        assertEquals(child.getLabel(), dto.getLabel());
+        assertEquals(child.getTransactionType(), dto.getTransactionType());
+        assertEquals(child.getSmoothType(), dto.getSmoothType());
+        assertEquals(child.getIcon(), dto.getIcon());
+        assertEquals(parent.getId(), dto.getParentId());
+        assertNotNull(dto.getTargets());
+        assertEquals(1, dto.getTargets().size());
+        TargetDTO t = dto.getTargets().get(0);
+        assertEquals(target.getId(), t.getId());
+        assertEquals(child.getId(), t.getCategoryId());
+        assertEquals(target.getAmount(), t.getAmount());
+    }
+
+    @Test
+    void testToEntityUsesRepository() throws Exception {
+        CategoryRepository repo = mock(CategoryRepository.class);
+
+        Category parent = new Category();
+        parent.setId(1L);
+        when(repo.findById(1L)).thenReturn(Optional.of(parent));
+
+        Category childFromRepo = new Category();
+        childFromRepo.setId(2L);
+        when(repo.findById(2L)).thenReturn(Optional.of(childFromRepo));
+
+        TargetMapperImpl targetMapper = new TargetMapperImpl();
+        inject(targetMapper, TargetMapper.class, "categoryRepository", repo);
+
+        CategoryMapperImpl mapper = new CategoryMapperImpl();
+        inject(mapper, CategoryMapper.class, "categoryRepository", repo);
+        inject(mapper, CategoryMapperImpl.class, "targetMapper", targetMapper);
+
+        TargetDTO targetDTO = new TargetDTO();
+        targetDTO.setId(5L);
+        targetDTO.setCategoryId(2L);
+        targetDTO.setAmount(100L);
+
+        CategoryDTO dto = new CategoryDTO();
+        dto.setId(2L);
+        dto.setParentId(1L);
+        dto.setLabel("Food");
+        dto.setTransactionType(TransactionType.EXPENSE);
+        dto.setSmoothType(CategorySmoothType.MONTHLY);
+        dto.setIcon("icon");
+        dto.setTargets(List.of(targetDTO));
+
+        Category entity = mapper.toEntity(dto);
+
+        assertEquals(dto.getId(), entity.getId());
+        assertEquals(dto.getLabel(), entity.getLabel());
+        assertEquals(dto.getTransactionType(), entity.getTransactionType());
+        assertEquals(dto.getSmoothType(), entity.getSmoothType());
+        assertEquals(dto.getIcon(), entity.getIcon());
+        assertSame(parent, entity.getParent());
+        assertNotNull(entity.getTargets());
+        assertEquals(1, entity.getTargets().size());
+        Target mappedTarget = entity.getTargets().get(0);
+        assertEquals(targetDTO.getId(), mappedTarget.getId());
+        assertEquals(targetDTO.getAmount(), mappedTarget.getAmount());
+        assertSame(childFromRepo, mappedTarget.getCategory());
+        verify(repo).findById(1L);
+        verify(repo).findById(2L);
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/TargetMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/TargetMapperTest.java
@@ -1,0 +1,59 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.TargetDTO;
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.Target;
+import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TargetMapperTest {
+
+    @Test
+    void testToDto() {
+        Category category = new Category();
+        category.setId(3L);
+
+        Target target = new Target();
+        target.setId(5L);
+        target.setCategory(category);
+        target.setAmount(100L);
+
+        TargetMapper mapper = new TargetMapperImpl();
+        TargetDTO dto = mapper.toDto(target);
+
+        assertEquals(target.getId(), dto.getId());
+        assertEquals(target.getCategory().getId(), dto.getCategoryId());
+        assertEquals(target.getAmount(), dto.getAmount());
+    }
+
+    @Test
+    void testToEntityUsesRepository() throws Exception {
+        CategoryRepository repo = mock(CategoryRepository.class);
+        Category category = new Category();
+        category.setId(7L);
+        when(repo.findById(7L)).thenReturn(Optional.of(category));
+
+        TargetMapperImpl mapper = new TargetMapperImpl();
+        Field f = TargetMapper.class.getDeclaredField("categoryRepository");
+        f.setAccessible(true);
+        f.set(mapper, repo);
+
+        TargetDTO dto = new TargetDTO();
+        dto.setId(8L);
+        dto.setCategoryId(7L);
+        dto.setAmount(200L);
+
+        Target entity = mapper.toEntity(dto);
+
+        assertEquals(dto.getId(), entity.getId());
+        assertEquals(dto.getAmount(), entity.getAmount());
+        assertSame(category, entity.getCategory());
+        verify(repo).findById(7L);
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/TransactionMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/TransactionMapperTest.java
@@ -1,0 +1,88 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.TransactionDTO;
+import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TransactionMapperTest {
+
+    private static void inject(Object target, Class<?> owner, String fieldName, Object value) throws Exception {
+        Field f = owner.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    @Test
+    void testToDto() {
+        Account account = new Account();
+        account.setId(2L);
+        Category category = new Category();
+        category.setId(3L);
+
+        Transaction tx = new Transaction();
+        tx.setId(4L);
+        tx.setAccount(account);
+        tx.setCategory(category);
+        tx.setDate(LocalDate.of(2024,1,1));
+        tx.setAmount(500L);
+        tx.setDescription("Desc");
+
+        TransactionMapper mapper = new TransactionMapperImpl();
+        TransactionDTO dto = mapper.toDto(tx);
+
+        assertEquals(tx.getId(), dto.getId());
+        assertEquals(account.getId(), dto.getAccountId());
+        assertEquals(category.getId(), dto.getCategoryId());
+        assertEquals(tx.getDate(), dto.getDate());
+        assertEquals(tx.getAmount(), dto.getAmount());
+        assertEquals(tx.getDescription(), dto.getDescription());
+    }
+
+    @Test
+    void testToEntityUsesRepositories() throws Exception {
+        AccountRepository accRepo = mock(AccountRepository.class);
+        CategoryRepository catRepo = mock(CategoryRepository.class);
+
+        Account account = new Account();
+        account.setId(2L);
+        when(accRepo.findById(2L)).thenReturn(Optional.of(account));
+
+        Category category = new Category();
+        category.setId(3L);
+        when(catRepo.findById(3L)).thenReturn(Optional.of(category));
+
+        TransactionMapperImpl mapper = new TransactionMapperImpl();
+        inject(mapper, TransactionMapper.class, "accountRepository", accRepo);
+        inject(mapper, TransactionMapper.class, "categoryRepository", catRepo);
+
+        TransactionDTO dto = new TransactionDTO();
+        dto.setId(4L);
+        dto.setAccountId(2L);
+        dto.setCategoryId(3L);
+        dto.setDate(LocalDate.of(2024,2,2));
+        dto.setAmount(600L);
+        dto.setDescription("Desc");
+
+        Transaction entity = mapper.toEntity(dto);
+
+        assertEquals(dto.getId(), entity.getId());
+        assertSame(account, entity.getAccount());
+        assertSame(category, entity.getCategory());
+        assertEquals(dto.getDate(), entity.getDate());
+        assertEquals(dto.getAmount(), entity.getAmount());
+        assertEquals(dto.getDescription(), entity.getDescription());
+        verify(accRepo).findById(2L);
+        verify(catRepo).findById(3L);
+    }
+}


### PR DESCRIPTION
## Summary
- add mapper tests covering all DTO/entity conversions

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_685d5738742883248bc9b5d9e56d4538