### PR TITLE
Add unit tests for projection interfaces

### DIFF
--- a/backend/src/test/java/com/lennartmoeller/finance/projection/AccountBalanceProjectionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/projection/AccountBalanceProjectionTest.java
@@ -1,0 +1,33 @@
+package com.lennartmoeller.finance.projection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountBalanceProjectionTest {
+
+    @Test
+    void testSimpleImplementation() {
+        AccountBalanceProjection p = new SimpleProjection(1L, 200L, 3L);
+        assertEquals(1L, p.getAccountId());
+        assertEquals(200L, p.getBalance());
+        assertEquals(3L, p.getTransactionCount());
+    }
+
+    private static class SimpleProjection implements AccountBalanceProjection {
+        private final Long accountId;
+        private final Long balance;
+        private final Long transactionCount;
+        SimpleProjection(Long accountId, Long balance, Long transactionCount) {
+            this.accountId = accountId;
+            this.balance = balance;
+            this.transactionCount = transactionCount;
+        }
+        @Override
+        public Long getAccountId() { return accountId; }
+        @Override
+        public Long getBalance() { return balance; }
+        @Override
+        public Long getTransactionCount() { return transactionCount; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/projection/DailyBalanceProjectionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/projection/DailyBalanceProjectionTest.java
@@ -1,0 +1,44 @@
+package com.lennartmoeller.finance.projection;
+
+import com.lennartmoeller.finance.model.Category;
+import com.lennartmoeller.finance.model.TransactionType;
+import com.lennartmoeller.finance.model.CategorySmoothType;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DailyBalanceProjectionTest {
+
+    @Test
+    void testSimpleImplementation() {
+        Category category = new Category();
+        category.setLabel("Test");
+        category.setTransactionType(TransactionType.INCOME);
+        category.setSmoothType(CategorySmoothType.DAILY);
+        LocalDate date = LocalDate.of(2024, 1, 1);
+
+        DailyBalanceProjection p = new SimpleProjection(date, category, 100L);
+        assertEquals(date, p.getDate());
+        assertEquals(category, p.getCategory());
+        assertEquals(100L, p.getBalance());
+    }
+
+    private static class SimpleProjection implements DailyBalanceProjection {
+        private final LocalDate date;
+        private final Category category;
+        private final Long balance;
+        SimpleProjection(LocalDate date, Category category, Long balance) {
+            this.date = date;
+            this.category = category;
+            this.balance = balance;
+        }
+        @Override
+        public LocalDate getDate() { return date; }
+        @Override
+        public Category getCategory() { return category; }
+        @Override
+        public Long getBalance() { return balance; }
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/projection/MonthlyDepositsProjectionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/projection/MonthlyDepositsProjectionTest.java
@@ -1,0 +1,28 @@
+package com.lennartmoeller.finance.projection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MonthlyDepositsProjectionTest {
+
+    @Test
+    void testSimpleImplementation() {
+        MonthlyDepositsProjection p = new SimpleProjection("2024-05", 1500L);
+        assertEquals("2024-05", p.getYearMonth());
+        assertEquals(1500L, p.getDeposits());
+    }
+
+    private static class SimpleProjection implements MonthlyDepositsProjection {
+        private final String yearMonth;
+        private final Long deposits;
+        SimpleProjection(String yearMonth, Long deposits) {
+            this.yearMonth = yearMonth;
+            this.deposits = deposits;
+        }
+        @Override
+        public String getYearMonth() { return yearMonth; }
+        @Override
+        public Long getDeposits() { return deposits; }
+    }
+}


### PR DESCRIPTION
## Summary
- create tests for AccountBalanceProjection, DailyBalanceProjection and MonthlyDepositsProjection

## Testing
- `./mvnw test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_685d58f07d0483248fcaf4266d2beab8