### PR TITLE
Add pinned flag for transactions

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionController.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionController.java
@@ -18,13 +18,14 @@ public class TransactionController {
 	private final TransactionService transactionService;
 
 	@GetMapping
-	public List<TransactionDTO> getTransactions(
-		@RequestParam(required = false) List<Long> accountIds,
-		@RequestParam(required = false) List<Long> categoryIds,
-		@RequestParam(required = false) List<YearMonth> yearMonths
-	) {
-		return transactionService.findFiltered(accountIds, categoryIds, yearMonths);
-	}
+        public List<TransactionDTO> getTransactions(
+                @RequestParam(required = false) List<Long> accountIds,
+                @RequestParam(required = false) List<Long> categoryIds,
+                @RequestParam(required = false) List<YearMonth> yearMonths,
+                @RequestParam(required = false) Boolean pinned
+        ) {
+                return transactionService.findFiltered(accountIds, categoryIds, yearMonths, pinned);
+        }
 
 	@GetMapping("/{id}")
 	public ResponseEntity<TransactionDTO> getTransactionById(@PathVariable Long id) {

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
@@ -15,7 +15,8 @@ public class TransactionDTO {
 	private Long accountId;
 	private Long categoryId;
 	private LocalDate date;
-	private Long amount;
-	private String description;
+        private Long amount;
+        private String description;
+        private Boolean pinned;
 
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
@@ -33,7 +33,10 @@ public class Transaction {
 	@Column(nullable = false)
 	private Long amount;
 
-	@Column(nullable = false)
-	private String description = "";
+        @Column(nullable = false)
+        private String description = "";
+
+        @Column(nullable = false)
+        private Boolean pinned = false;
 
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
@@ -14,14 +14,16 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 	@Query("""
 		    SELECT t
 		    FROM Transaction t
-		    WHERE (:accountIds IS NULL OR t.account.id IN :accountIds)
-		    AND (:categoryIds IS NULL OR t.category.id IN :categoryIds)
-		    AND (:yearMonths IS NULL OR FUNCTION('TO_CHAR', t.date, 'YYYY-MM') IN :yearMonths)
-		""")
-	List<Transaction> findFiltered(
-		@Nullable List<Long> accountIds,
-		@Nullable List<Long> categoryIds,
-		@Nullable List<String> yearMonths);
+                    WHERE (:accountIds IS NULL OR t.account.id IN :accountIds)
+                    AND (:categoryIds IS NULL OR t.category.id IN :categoryIds)
+                    AND (:yearMonths IS NULL OR FUNCTION('TO_CHAR', t.date, 'YYYY-MM') IN :yearMonths)
+                    AND (:pinned IS NULL OR t.pinned = :pinned)
+                """)
+        List<Transaction> findFiltered(
+                @Nullable List<Long> accountIds,
+                @Nullable List<Long> categoryIds,
+                @Nullable List<String> yearMonths,
+                @Nullable Boolean pinned);
 
 	@Query("""
 		    SELECT t.date AS date,

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
@@ -21,16 +21,17 @@ public class TransactionService {
 	private final TransactionRepository transactionRepository;
 	private final TransactionMapper transactionMapper;
 
-	public List<TransactionDTO> findFiltered(
-		@Nullable List<Long> accountIds,
-		@Nullable List<Long> categoryIds,
-		@Nullable List<YearMonth> yearMonths
-	) {
+        public List<TransactionDTO> findFiltered(
+                @Nullable List<Long> accountIds,
+                @Nullable List<Long> categoryIds,
+                @Nullable List<YearMonth> yearMonths,
+                @Nullable Boolean pinned
+        ) {
 		List<Long> extendedCategoryIds = categoryService.collectChildCategoryIdsRecursively(categoryIds);
 
 		List<String> yearMonthStrings = yearMonths == null ? null : yearMonths.stream().map(YearMonth::toString).toList();
 
-		List<Transaction> transactions = transactionRepository.findFiltered(accountIds, extendedCategoryIds, yearMonthStrings);
+                List<Transaction> transactions = transactionRepository.findFiltered(accountIds, extendedCategoryIds, yearMonthStrings, pinned);
 		return transactions.stream()
 			.sorted(Comparator.comparing(Transaction::getDate).thenComparing(Transaction::getId))
 			.map(transactionMapper::toDto)

--- a/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionControllerTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionControllerTest.java
@@ -31,14 +31,14 @@ class TransactionControllerTest {
 	void testGetTransactions() {
 		List<Long> aIds = List.of(1L, 2L);
 		List<Long> cIds = List.of(3L);
-		List<YearMonth> months = List.of(YearMonth.of(2024, 1));
-		List<TransactionDTO> list = List.of(new TransactionDTO());
-		when(service.findFiltered(aIds, cIds, months)).thenReturn(list);
+                List<YearMonth> months = List.of(YearMonth.of(2024, 1));
+                List<TransactionDTO> list = List.of(new TransactionDTO());
+                when(service.findFiltered(aIds, cIds, months, true)).thenReturn(list);
 
-		List<TransactionDTO> result = controller.getTransactions(aIds, cIds, months);
+                List<TransactionDTO> result = controller.getTransactions(aIds, cIds, months, true);
 
-		assertEquals(list, result);
-		verify(service).findFiltered(aIds, cIds, months);
+                assertEquals(list, result);
+                verify(service).findFiltered(aIds, cIds, months, true);
 	}
 
 	@Test

--- a/backend/src/test/java/com/lennartmoeller/finance/repository/TransactionRepositoryTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/repository/TransactionRepositoryTest.java
@@ -77,8 +77,8 @@ class TransactionRepositoryTest {
 	@Test
 	void testFindFiltered() {
 		List<String> jan = List.of("2021-01");
-		List<Transaction> result = transactionRepository.findFiltered(
-			List.of(depositAcc.getId()), List.of(cat1.getId()), jan);
+                List<Transaction> result = transactionRepository.findFiltered(
+                        List.of(depositAcc.getId()), List.of(cat1.getId()), jan, null);
 		assertEquals(2, result.size());
 		for (Transaction t : result) {
 			assertEquals(depositAcc.getId(), t.getAccount().getId());
@@ -87,7 +87,7 @@ class TransactionRepositoryTest {
 			assertEquals(1, t.getDate().getMonthValue());
 		}
 
-		List<Transaction> all = transactionRepository.findFiltered(null, null, null);
+                List<Transaction> all = transactionRepository.findFiltered(null, null, null, null);
 		assertEquals(5, all.size());
 	}
 

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
@@ -49,7 +49,7 @@ class TransactionServiceTest {
 		Transaction t3 = new Transaction();
 		t3.setId(3L);
 		t3.setDate(LocalDate.of(2021, 1, 11));
-		when(transactionRepository.findFiltered(accountIds, extendedCategoryIds, monthStrings)).thenReturn(List.of(t1, t2, t3));
+                when(transactionRepository.findFiltered(accountIds, extendedCategoryIds, monthStrings, null)).thenReturn(List.of(t1, t2, t3));
 
 		TransactionDTO d1 = new TransactionDTO();
 		TransactionDTO d2 = new TransactionDTO();
@@ -58,18 +58,18 @@ class TransactionServiceTest {
 		when(transactionMapper.toDto(t2)).thenReturn(d2);
 		when(transactionMapper.toDto(t3)).thenReturn(d3);
 
-		List<TransactionDTO> result = service.findFiltered(accountIds, categoryIds, months);
+                List<TransactionDTO> result = service.findFiltered(accountIds, categoryIds, months, null);
 
 		assertEquals(List.of(d2, d1, d3), result); // sorted by date then id
-		verify(transactionRepository).findFiltered(accountIds, extendedCategoryIds, monthStrings);
+                verify(transactionRepository).findFiltered(accountIds, extendedCategoryIds, monthStrings, null);
 	}
 
 	@Test
 	void testFindFilteredNullParameters() {
 		when(categoryService.collectChildCategoryIdsRecursively(null)).thenReturn(null);
-		when(transactionRepository.findFiltered(null, null, null)).thenReturn(List.of());
+                when(transactionRepository.findFiltered(null, null, null, null)).thenReturn(List.of());
 
-		List<TransactionDTO> result = service.findFiltered(null, null, null);
+                List<TransactionDTO> result = service.findFiltered(null, null, null, null);
 
 		assertTrue(result.isEmpty());
 	}


### PR DESCRIPTION
## Summary
- support pinned status in `Transaction` model
- allow filtering transactions by pinned state
- extend service and controller to handle new `pinned` filter
- update DTO and tests accordingly

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_685d846152b083248a122038a19e9df4