### PR TITLE
Simplify output of git commit hooks

### DIFF
--- a/.git-hooks/commit-msg
+++ b/.git-hooks/commit-msg
@@ -5,11 +5,10 @@ REGEX="^((Merge[ a-z-]* branch.*)|(Revert*)|((build|chore|ci|docs|feat|fix|perf|
 
 FILE=$(cat "$1") # File containing the commit message
 
-echo "Commit Message: ${FILE}"
-
-if ! [[ $FILE =~ $REGEX ]]; then
-	echo >&2 "ERROR: Commit aborted for not following the Conventional Commit standard.​"
-	exit 1
+if [[ $FILE =~ $REGEX ]]; then
+    echo "✅ Commit message follows Conventional Commit standard"
+    exit 0
 else
-	echo >&2 "Valid commit message."
+    echo "❌ Commit message does not follow Conventional Commit standard"
+    exit 1
 fi

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,8 +1,30 @@
 #!/bin/bash
-# Git pre-commit hook to format backend code and run tests
-set -e
+# Git pre-commit hook to format backend code and run tests with concise output
+
 repo_root="$(git rev-parse --show-toplevel)"
-cd "$repo_root/backend"
+cd "$repo_root/backend" || exit 1
 chmod +x ./mvnw
-./mvnw spotless:apply
-./mvnw test
+
+# run formatter
+./mvnw spotless:apply >/dev/null 2>&1
+format_status=$?
+
+# run tests
+./mvnw test >/dev/null 2>&1
+test_status=$?
+
+if [ $format_status -eq 0 ]; then
+    echo "✅ Backend code is formatted"
+else
+    echo "❌ Backend code formatting failed"
+fi
+
+if [ $test_status -eq 0 ]; then
+    echo "✅ Backend tests passed"
+else
+    echo "❌ Backend tests failed"
+fi
+
+if [ $format_status -ne 0 ] || [ $test_status -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- streamline commit-msg hook to only show success/failure
- update pre-commit hook to print concise results for formatting and tests

## Testing
- `cd backend && chmod +x ./mvnw && ./mvnw spotless:apply`
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_685ef7d8c9248324b341c0f5e36ed85f