### PR TITLE
Add CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Project CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate commit messages
+        run: |
+          regex="^((Merge[ a-z-]* branch.*)|(Revert*)|((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.*\\))?!?: .*))"
+          commits=$(git log "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" --format=%s)
+          status=0
+          while IFS= read -r msg; do
+            if [[ ! $msg =~ $regex ]]; then
+              echo "\u274c '$msg' does not follow Conventional Commit standard"
+              status=1
+            else
+              echo "\u2705 '$msg' follows Conventional Commit standard"
+            fi
+          done <<< "$commits"
+          exit $status
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Check formatting
+        run: |
+          cd backend
+          chmod +x ./mvnw
+          ./mvnw spotless:check
+
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Run tests
+        run: |
+          cd backend
+          chmod +x ./mvnw
+          ./mvnw test


### PR DESCRIPTION
## Summary
- automate commit message validation using regex from commit-msg hook
- verify backend formatting with `spotless:check`
- run backend tests in CI
- rename workflow and pipeline name for future frontend additions

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_685efcdc04fc832493b90849b2d3f203