### PR TITLE
feat: add CSV import endpoint

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/controller/BankTransactionController.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/controller/BankTransactionController.java
@@ -1,0 +1,27 @@
+package com.lennartmoeller.finance.controller;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.model.BankType;
+import com.lennartmoeller.finance.service.BankCsvImportService;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/bank-transactions")
+@RequiredArgsConstructor
+public class BankTransactionController {
+
+    private final BankCsvImportService importService;
+
+    @PostMapping("/import")
+    public List<BankTransactionDTO> importCsv(
+            @RequestParam("type") BankType type, @RequestParam("file") MultipartFile file) throws IOException {
+        return importService.importCsv(type, file);
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/converter/MapToJsonStringConverter.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/converter/MapToJsonStringConverter.java
@@ -1,0 +1,39 @@
+package com.lennartmoeller.finance.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Converter
+public class MapToJsonStringConverter implements AttributeConverter<Map<String, String>, String> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, String> attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Cannot write map to JSON", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return new HashMap<>();
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<Map<String, String>>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot read JSON to map", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/csv/BankCsvParser.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/csv/BankCsvParser.java
@@ -1,0 +1,10 @@
+package com.lennartmoeller.finance.csv;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+public interface BankCsvParser<T extends BankTransactionDTO> {
+    List<T> parse(InputStream inputStream) throws IOException;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/csv/CamtV8CsvParser.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/csv/CamtV8CsvParser.java
@@ -1,0 +1,84 @@
+package com.lennartmoeller.finance.csv;
+
+import com.lennartmoeller.finance.dto.CamtV8TransactionDTO;
+import com.lennartmoeller.finance.model.BankType;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CamtV8CsvParser implements BankCsvParser<CamtV8TransactionDTO> {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("dd.MM.yy");
+
+    @Override
+    public List<CamtV8TransactionDTO> parse(InputStream inputStream) throws IOException {
+        List<String> lines = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+                .lines()
+                .toList();
+        if (lines.isEmpty()) {
+            return List.of();
+        }
+        String[] headers = parseLine(lines.get(0));
+        List<CamtV8TransactionDTO> result = new ArrayList<>();
+        for (int r = 1; r < lines.size(); r++) {
+            String line = lines.get(r);
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] values = parseLine(line);
+            if (values.length < headers.length) {
+                continue;
+            }
+            Map<String, String> map = new LinkedHashMap<>();
+            for (int i = 0; i < headers.length; i++) {
+                map.put(headers[i], values[i]);
+            }
+            Map<String, Integer> idx = new java.util.HashMap<>();
+            for (int i = 0; i < headers.length; i++) {
+                idx.put(headers[i], i);
+            }
+            CamtV8TransactionDTO dto = new CamtV8TransactionDTO();
+            dto.setBank(BankType.CAMT_V8);
+            dto.setIban(values[idx.get("Kontonummer/IBAN")]);
+            dto.setBookingDate(LocalDate.parse(values[idx.get("Buchungstag")], DATE));
+            dto.setValueDate(LocalDate.parse(values[idx.get("Valutadatum")], DATE));
+            dto.setBookingText(values[idx.get("Buchungstext")]);
+            dto.setPurpose(values[idx.get("Verwendungszweck")]);
+            dto.setCounterparty(values[idx.get("Beguenstigter/Zahlungspflichtiger")]);
+            dto.setAmount(EuroParser.parseToCents(values[idx.get("Betrag")]));
+            dto.setCurrency(values[idx.get("Waehrung")]);
+            dto.setCreditorId(values[idx.get("Glaeubiger ID")]);
+            dto.setMandateReference(values[idx.get("Mandatsreferenz")]);
+            dto.setCustomerReference(values[idx.get("Kundenreferenz (End-to-End)")]);
+            dto.setCollectorReference(values[idx.get("Sammlerreferenz")]);
+            dto.setDirectDebitOriginalAmount(values[idx.get("Lastschrift Ursprungsbetrag")]);
+            dto.setRefundFee(values[idx.get("Auslagenersatz Ruecklastschrift")]);
+            dto.setBic(values[idx.get("BIC (SWIFT-Code)")]);
+            dto.setInfo(values[idx.get("Info")]);
+            dto.setData(map);
+            result.add(dto);
+        }
+        return result;
+    }
+
+    private String[] parseLine(String line) {
+        line = line.trim();
+        if (line.startsWith("\uFEFF")) {
+            line = line.substring(1);
+        }
+        if (line.startsWith("\"") && line.endsWith("\"")) {
+            line = line.substring(1, line.length() - 1);
+        }
+        return line.split("\";\"");
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/csv/EuroParser.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/csv/EuroParser.java
@@ -1,0 +1,21 @@
+package com.lennartmoeller.finance.csv;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+public final class EuroParser {
+    private EuroParser() {}
+
+    public static Long parseToCents(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            Number number = NumberFormat.getNumberInstance(Locale.GERMANY).parse(text.replace("\u00A0", ""));
+            return Math.round(number.doubleValue() * 100);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Invalid amount: " + text, e);
+        }
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/csv/IngV1CsvParser.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/csv/IngV1CsvParser.java
@@ -1,0 +1,78 @@
+package com.lennartmoeller.finance.csv;
+
+import com.lennartmoeller.finance.dto.IngV1TransactionDTO;
+import com.lennartmoeller.finance.model.BankType;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IngV1CsvParser implements BankCsvParser<IngV1TransactionDTO> {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+    @Override
+    public List<IngV1TransactionDTO> parse(InputStream inputStream) throws IOException {
+        List<String> lines = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+                .lines()
+                .toList();
+        String iban = lines.stream()
+                .filter(l -> l.startsWith("IBAN;"))
+                .map(l -> l.split(";", 2)[1])
+                .findFirst()
+                .orElse("");
+        int headerIdx = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).startsWith("Buchung;")) {
+                headerIdx = i;
+                break;
+            }
+        }
+        String[] headers = lines.get(headerIdx).split(";");
+        List<IngV1TransactionDTO> result = new ArrayList<>();
+        for (int idx = headerIdx + 1; idx < lines.size(); idx++) {
+            String line = lines.get(idx);
+            if (line.isBlank()) {
+                continue;
+            }
+            String[] values = line.split(";", -1);
+            if (values.length < headers.length) {
+                continue;
+            }
+            Map<String, String> map = new LinkedHashMap<>();
+            for (int i = 0; i < headers.length; i++) {
+                String key = headers[i];
+                if (map.containsKey(key)) {
+                    key = key + '_' + i;
+                }
+                map.put(key, values[i]);
+            }
+            map.put("IBAN", iban);
+
+            IngV1TransactionDTO dto = new IngV1TransactionDTO();
+            dto.setBank(BankType.ING_V1);
+            dto.setIban(iban);
+            dto.setBookingDate(LocalDate.parse(values[0], DATE));
+            dto.setValueDate(LocalDate.parse(values[1], DATE));
+            dto.setCounterparty(values[2]);
+            dto.setBookingText(values[3]);
+            dto.setPurpose(values[4]);
+            dto.setBalance(EuroParser.parseToCents(values[5]));
+            dto.setBalanceCurrency(values[6]);
+            dto.setAmount(EuroParser.parseToCents(values[7]));
+            dto.setAmountCurrency(values[8]);
+            dto.setData(map);
+            result.add(dto);
+        }
+        return result;
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/BankTransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/BankTransactionDTO.java
@@ -1,0 +1,22 @@
+package com.lennartmoeller.finance.dto;
+
+import com.lennartmoeller.finance.model.BankType;
+import java.time.LocalDate;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+@Setter
+public class BankTransactionDTO {
+    private Long id;
+    private BankType bank;
+    private String iban;
+    private LocalDate bookingDate;
+    private String purpose;
+    private String counterparty;
+    private Long amount;
+    private Map<String, String> data;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/CamtV8TransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/CamtV8TransactionDTO.java
@@ -1,0 +1,23 @@
+package com.lennartmoeller.finance.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+@Setter
+public class CamtV8TransactionDTO extends BankTransactionDTO {
+    private LocalDate valueDate;
+    private String bookingText;
+    private String creditorId;
+    private String mandateReference;
+    private String customerReference;
+    private String collectorReference;
+    private String directDebitOriginalAmount;
+    private String refundFee;
+    private String bic;
+    private String currency;
+    private String info;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/IngV1TransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/IngV1TransactionDTO.java
@@ -1,0 +1,17 @@
+package com.lennartmoeller.finance.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+@Setter
+public class IngV1TransactionDTO extends BankTransactionDTO {
+    private LocalDate valueDate;
+    private String bookingText;
+    private Long balance;
+    private String balanceCurrency;
+    private String amountCurrency;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/BankTransactionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/BankTransactionMapper.java
@@ -1,0 +1,22 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.dto.CamtV8TransactionDTO;
+import com.lennartmoeller.finance.dto.IngV1TransactionDTO;
+import com.lennartmoeller.finance.model.BankTransaction;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface BankTransactionMapper {
+
+    BankTransactionDTO toDto(BankTransaction entity);
+
+    BankTransaction toEntity(BankTransactionDTO dto);
+
+    @Mapping(target = "bank", constant = "ING_V1")
+    BankTransaction toEntity(IngV1TransactionDTO dto);
+
+    @Mapping(target = "bank", constant = "CAMT_V8")
+    BankTransaction toEntity(CamtV8TransactionDTO dto);
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
@@ -1,0 +1,48 @@
+package com.lennartmoeller.finance.model;
+
+import com.lennartmoeller.finance.converter.MapToJsonStringConverter;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@Table(
+        name = "bank_transactions",
+        uniqueConstraints =
+                @UniqueConstraint(columnNames = {"iban", "booking_date", "purpose", "counterparty", "amount"}))
+public class BankTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BankType bank;
+
+    @Column(nullable = false)
+    private String iban;
+
+    @Column(name = "booking_date", nullable = false)
+    private LocalDate bookingDate;
+
+    @Column(nullable = false, length = 1024)
+    private String purpose;
+
+    @Column(nullable = false, length = 1024)
+    private String counterparty;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Lob
+    @Convert(converter = MapToJsonStringConverter.class)
+    private Map<String, String> data = new HashMap<>();
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/model/BankType.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BankType.java
@@ -1,0 +1,6 @@
+package com.lennartmoeller.finance.model;
+
+public enum BankType {
+    CAMT_V8,
+    ING_V1
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Target.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Target.java
@@ -22,11 +22,9 @@ public class Target {
     private Category category;
 
     @Column(nullable = false)
-    @Temporal(TemporalType.DATE)
     private LocalDate startDate;
 
     @Column
-    @Temporal(TemporalType.DATE)
     private LocalDate endDate;
 
     @Column

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
@@ -26,7 +26,6 @@ public class Transaction {
     private Category category;
 
     @Column(nullable = false)
-    @Temporal(TemporalType.DATE)
     private LocalDate date = LocalDate.now();
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/BankTransactionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/BankTransactionRepository.java
@@ -1,0 +1,10 @@
+package com.lennartmoeller.finance.repository;
+
+import com.lennartmoeller.finance.model.BankTransaction;
+import java.time.LocalDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankTransactionRepository extends JpaRepository<BankTransaction, Long> {
+    boolean existsByIbanAndBookingDateAndPurposeAndCounterpartyAndAmount(
+            String iban, LocalDate bookingDate, String purpose, String counterparty, Long amount);
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/service/BankCsvImportService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/BankCsvImportService.java
@@ -1,0 +1,55 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.csv.CamtV8CsvParser;
+import com.lennartmoeller.finance.csv.IngV1CsvParser;
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.dto.CamtV8TransactionDTO;
+import com.lennartmoeller.finance.dto.IngV1TransactionDTO;
+import com.lennartmoeller.finance.mapper.BankTransactionMapper;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.BankType;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class BankCsvImportService {
+
+    private final BankTransactionRepository repository;
+    private final BankTransactionMapper mapper;
+    private final IngV1CsvParser ingParser;
+    private final CamtV8CsvParser camtParser;
+
+    public List<BankTransactionDTO> importCsv(BankType type, MultipartFile file) throws IOException {
+        List<? extends BankTransactionDTO> parsed;
+        try (var is = file.getInputStream()) {
+            parsed = switch (type) {
+                case ING_V1 -> ingParser.parse(is);
+                case CAMT_V8 -> camtParser.parse(is);
+            };
+        }
+        List<BankTransactionDTO> saved = new ArrayList<>();
+        for (BankTransactionDTO dto : parsed) {
+            if (repository.existsByIbanAndBookingDateAndPurposeAndCounterpartyAndAmount(
+                    dto.getIban(), dto.getBookingDate(), dto.getPurpose(), dto.getCounterparty(), dto.getAmount())) {
+                continue;
+            }
+            BankTransaction entity;
+            if (dto instanceof IngV1TransactionDTO ing) {
+                entity = mapper.toEntity(ing);
+            } else if (dto instanceof CamtV8TransactionDTO camt) {
+                entity = mapper.toEntity(camt);
+            } else {
+                entity = mapper.toEntity(dto);
+            }
+            BankTransaction persisted = repository.save(entity);
+            saved.add(mapper.toDto(persisted));
+        }
+        return saved;
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/controller/BankTransactionControllerTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/controller/BankTransactionControllerTest.java
@@ -1,0 +1,37 @@
+package com.lennartmoeller.finance.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.model.BankType;
+import com.lennartmoeller.finance.service.BankCsvImportService;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+class BankTransactionControllerTest {
+
+    private BankCsvImportService service;
+    private BankTransactionController controller;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(BankCsvImportService.class);
+        controller = new BankTransactionController(service);
+    }
+
+    @Test
+    void testImportCsv() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        BankTransactionDTO dto = new BankTransactionDTO();
+        when(service.importCsv(BankType.ING_V1, file)).thenReturn(List.of(dto));
+
+        List<BankTransactionDTO> result = controller.importCsv(BankType.ING_V1, file);
+
+        assertEquals(List.of(dto), result);
+        verify(service).importCsv(BankType.ING_V1, file);
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/BankTransactionMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/BankTransactionMapperTest.java
@@ -1,0 +1,31 @@
+package com.lennartmoeller.finance.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.lennartmoeller.finance.dto.IngV1TransactionDTO;
+import com.lennartmoeller.finance.model.BankTransaction;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class BankTransactionMapperTest {
+
+    @Test
+    void testIngV1ToEntity() {
+        IngV1TransactionDTO dto = new IngV1TransactionDTO();
+        dto.setIban("DE123");
+        dto.setBookingDate(LocalDate.of(2024, 1, 1));
+        dto.setPurpose("p");
+        dto.setCounterparty("c");
+        dto.setAmount(100L);
+
+        BankTransactionMapper mapper = new BankTransactionMapperImpl();
+        BankTransaction entity = mapper.toEntity(dto);
+
+        assertEquals(dto.getIban(), entity.getIban());
+        assertEquals(dto.getBookingDate(), entity.getBookingDate());
+        assertEquals(dto.getPurpose(), entity.getPurpose());
+        assertEquals(dto.getCounterparty(), entity.getCounterparty());
+        assertEquals(dto.getAmount(), entity.getAmount());
+        assertEquals("ING_V1", entity.getBank().name());
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/BankCsvImportServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/BankCsvImportServiceTest.java
@@ -1,0 +1,63 @@
+package com.lennartmoeller.finance.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.lennartmoeller.finance.csv.CamtV8CsvParser;
+import com.lennartmoeller.finance.csv.IngV1CsvParser;
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.dto.IngV1TransactionDTO;
+import com.lennartmoeller.finance.mapper.BankTransactionMapper;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.BankType;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+class BankCsvImportServiceTest {
+
+    private BankTransactionRepository repository;
+    private BankTransactionMapper mapper;
+    private IngV1CsvParser ingParser;
+    private CamtV8CsvParser camtParser;
+    private BankCsvImportService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(BankTransactionRepository.class);
+        mapper = mock(BankTransactionMapper.class);
+        ingParser = mock(IngV1CsvParser.class);
+        camtParser = mock(CamtV8CsvParser.class);
+        service = new BankCsvImportService(repository, mapper, ingParser, camtParser);
+    }
+
+    @Test
+    void testImportCsvFiltersDuplicates() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        IngV1TransactionDTO dto = new IngV1TransactionDTO();
+        dto.setIban("DE");
+        dto.setBookingDate(java.time.LocalDate.now());
+        dto.setPurpose("p");
+        dto.setCounterparty("c");
+        dto.setAmount(1L);
+        when(file.getInputStream()).thenReturn(InputStream.nullInputStream());
+        when(ingParser.parse(any())).thenReturn(List.of(dto));
+        when(repository.existsByIbanAndBookingDateAndPurposeAndCounterpartyAndAmount(any(), any(), any(), any(), any()))
+                .thenReturn(false);
+        BankTransaction entity = new BankTransaction();
+        when(mapper.toEntity(dto)).thenReturn(entity);
+        BankTransaction saved = new BankTransaction();
+        when(repository.save(entity)).thenReturn(saved);
+        BankTransactionDTO resultDto = new BankTransactionDTO();
+        when(mapper.toDto(saved)).thenReturn(resultDto);
+
+        List<BankTransactionDTO> result = service.importCsv(BankType.ING_V1, file);
+
+        assertEquals(List.of(resultDto), result);
+        verify(repository).save(entity);
+    }
+}


### PR DESCRIPTION
## Summary
- support uploading bank CSV files
- store uploaded data in new `bank_transactions` table with Map -> JSON converter
- parse ING and CAMT v8 CSV formats
- add mapper, service and controller for imports
- add unit tests for new components
- remove obsolete `@Temporal` annotations

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_685f0c617c908324a3ab7132a88d7e1f