### PR TITLE
Fix mapstruct deposit mapping

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/dto/AccountDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/AccountDTO.java
@@ -13,4 +13,5 @@ public class AccountDTO {
     private String label;
     private Long startBalance;
     private Boolean active;
+    private Boolean deposits;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TargetMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TargetMapper.java
@@ -16,9 +16,13 @@ public abstract class TargetMapper {
     private CategoryRepository categoryRepository;
 
     @Mapping(source = "category.id", target = "categoryId")
+    @Mapping(source = "startDate", target = "start")
+    @Mapping(source = "endDate", target = "end")
     public abstract TargetDTO toDto(Target target);
 
     @Mapping(target = "category", source = "categoryId", qualifiedByName = "mapCategoryIdToCategory")
+    @Mapping(source = "start", target = "startDate")
+    @Mapping(source = "end", target = "endDate")
     public abstract Target toEntity(TargetDTO targetDTO);
 
     @Named("mapCategoryIdToCategory")

--- a/backend/src/test/java/com/lennartmoeller/finance/dto/AccountDTOTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/dto/AccountDTOTest.java
@@ -1,6 +1,7 @@
 package com.lennartmoeller.finance.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -13,10 +14,12 @@ class AccountDTOTest {
         dto.setLabel("Checking");
         dto.setStartBalance(200L);
         dto.setActive(true);
+        dto.setDeposits(false);
 
         assertEquals(3L, dto.getId());
         assertEquals("Checking", dto.getLabel());
         assertEquals(200L, dto.getStartBalance());
         assertTrue(dto.getActive());
+        assertFalse(dto.getDeposits());
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
@@ -25,6 +25,7 @@ class AccountMapperTest {
         assertEquals(account.getLabel(), dto.getLabel());
         assertEquals(account.getStartBalance(), dto.getStartBalance());
         assertEquals(account.getActive(), dto.getActive());
+        assertEquals(account.getDeposits(), dto.getDeposits());
 
         Account entity = mapper.toEntity(dto);
         assertNotNull(entity);
@@ -32,8 +33,7 @@ class AccountMapperTest {
         assertEquals(account.getLabel(), entity.getLabel());
         assertEquals(account.getStartBalance(), entity.getStartBalance());
         assertEquals(account.getActive(), entity.getActive());
-        // deposits is not part of the DTO and should remain default (false)
-        assertFalse(entity.getDeposits());
+        assertEquals(account.getDeposits(), entity.getDeposits());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose `deposits` field on `AccountDTO`
- map deposits in `AccountMapper`
- adjust mapper and DTO tests

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_685f238e7c68832480de9ff072ac1860