### PR TITLE
fix(data): set timestamp defaults

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/AccountMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/AccountMapper.java
@@ -4,10 +4,10 @@ import com.lennartmoeller.finance.dto.AccountDTO;
 import com.lennartmoeller.finance.model.Account;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
-public abstract class AccountMapper {
+@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface AccountMapper {
 
-    public abstract AccountDTO toDto(Account account);
+    AccountDTO toDto(Account account);
 
-    public abstract Account toEntity(AccountDTO accountDTO);
+    Account toEntity(AccountDTO accountDTO);
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/BankTransactionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/BankTransactionMapper.java
@@ -7,16 +7,16 @@ import com.lennartmoeller.finance.model.BankTransaction;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
-public abstract class BankTransactionMapper {
+@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface BankTransactionMapper {
 
-    public abstract BankTransactionDTO toDto(BankTransaction entity);
+    BankTransactionDTO toDto(BankTransaction entity);
 
-    public abstract BankTransaction toEntity(BankTransactionDTO dto);
+    BankTransaction toEntity(BankTransactionDTO dto);
 
     @Mapping(target = "bank", constant = "ING_V1")
-    public abstract BankTransaction toEntity(IngV1TransactionDTO dto);
+    BankTransaction toEntity(IngV1TransactionDTO dto);
 
     @Mapping(target = "bank", constant = "CAMT_V8")
-    public abstract BankTransaction toEntity(CamtV8TransactionDTO dto);
+    BankTransaction toEntity(CamtV8TransactionDTO dto);
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/CategoryMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/CategoryMapper.java
@@ -3,32 +3,32 @@ package com.lennartmoeller.finance.mapper;
 import com.lennartmoeller.finance.dto.CategoryDTO;
 import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-import org.springframework.beans.factory.annotation.Autowired;
 
-@Mapper(componentModel = "spring", uses = TargetMapper.class)
-public abstract class CategoryMapper {
-
-    @Autowired
-    private CategoryRepository categoryRepository;
+@Mapper(
+        componentModel = "spring",
+        uses = TargetMapper.class,
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface CategoryMapper {
 
     @Mapping(source = "parent.id", target = "parentId")
     @Mapping(source = "targets", target = "targets")
-    public abstract CategoryDTO toDto(Category category);
+    CategoryDTO toDto(Category category);
 
     @Mapping(target = "parent", source = "parentId", qualifiedByName = "mapParentIdToParent")
     @Mapping(target = "targets", source = "targets")
-    public abstract Category toEntity(CategoryDTO categoryDTO);
+    Category toEntity(CategoryDTO dto, @Context CategoryRepository repository);
 
     @Named("mapParentIdToParent")
-    Category mapParentIdToParent(Long parentId) {
-        return parentId != null ? categoryRepository.findById(parentId).orElse(null) : null;
+    default Category mapParentIdToParent(Long parentId, @Context CategoryRepository repository) {
+        return parentId != null ? repository.findById(parentId).orElse(null) : null;
     }
 
     @Named("mapParentToParentId")
-    Long mapParentToParentId(Category parent) {
+    default Long mapParentToParentId(Category parent) {
         return parent != null ? parent.getId() : null;
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TargetMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TargetMapper.java
@@ -4,34 +4,34 @@ import com.lennartmoeller.finance.dto.TargetDTO;
 import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.model.Target;
 import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-import org.springframework.beans.factory.annotation.Autowired;
 
-@Mapper(componentModel = "spring", uses = CategoryMapper.class)
-public abstract class TargetMapper {
-
-    @Autowired
-    private CategoryRepository categoryRepository;
+@Mapper(
+        componentModel = "spring",
+        uses = CategoryMapper.class,
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface TargetMapper {
 
     @Mapping(source = "category.id", target = "categoryId")
     @Mapping(source = "startDate", target = "start")
     @Mapping(source = "endDate", target = "end")
-    public abstract TargetDTO toDto(Target target);
+    TargetDTO toDto(Target target);
 
     @Mapping(target = "category", source = "categoryId", qualifiedByName = "mapCategoryIdToCategory")
     @Mapping(source = "start", target = "startDate")
     @Mapping(source = "end", target = "endDate")
-    public abstract Target toEntity(TargetDTO targetDTO);
+    Target toEntity(TargetDTO targetDTO, @Context CategoryRepository repository);
 
     @Named("mapCategoryIdToCategory")
-    Category mapCategoryIdToCategory(Long categoryId) {
-        return categoryId != null ? categoryRepository.findById(categoryId).orElse(null) : null;
+    default Category mapCategoryIdToCategory(Long categoryId, @Context CategoryRepository repository) {
+        return categoryId != null ? repository.findById(categoryId).orElse(null) : null;
     }
 
     @Named("mapCategoryToCategoryId")
-    Long mapCategoryToCategoryId(Category category) {
+    default Long mapCategoryToCategoryId(Category category) {
         return category != null ? category.getId() : null;
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
@@ -6,47 +6,45 @@ import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(
         componentModel = "spring",
-        uses = {AccountMapper.class, CategoryMapper.class})
-public abstract class TransactionMapper {
-
-    @Autowired
-    private AccountRepository accountRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
+        uses = {AccountMapper.class, CategoryMapper.class},
+        unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface TransactionMapper {
 
     @Mapping(source = "account.id", target = "accountId")
     @Mapping(source = "category.id", target = "categoryId")
-    public abstract TransactionDTO toDto(Transaction transaction);
+    TransactionDTO toDto(Transaction transaction);
 
     @Mapping(target = "account", source = "accountId", qualifiedByName = "mapAccountIdToAccount")
     @Mapping(target = "category", source = "categoryId", qualifiedByName = "mapCategoryIdToCategory")
-    public abstract Transaction toEntity(TransactionDTO transactionDTO);
+    Transaction toEntity(
+            TransactionDTO dto,
+            @Context AccountRepository accountRepository,
+            @Context CategoryRepository categoryRepository);
 
     @Named("mapAccountIdToAccount")
-    Account mapAccountIdToAccount(Long accountId) {
-        return accountId != null ? accountRepository.findById(accountId).orElse(null) : null;
+    default Account mapAccountIdToAccount(Long accountId, @Context AccountRepository repository) {
+        return accountId != null ? repository.findById(accountId).orElse(null) : null;
     }
 
     @Named("mapAccountToAccountId")
-    Long mapAccountToAccountId(Account account) {
+    default Long mapAccountToAccountId(Account account) {
         return account != null ? account.getId() : null;
     }
 
     @Named("mapCategoryIdToCategory")
-    Category mapCategoryIdToCategory(Long categoryId) {
-        return categoryId != null ? categoryRepository.findById(categoryId).orElse(null) : null;
+    default Category mapCategoryIdToCategory(Long categoryId, @Context CategoryRepository repository) {
+        return categoryId != null ? repository.findById(categoryId).orElse(null) : null;
     }
 
     @Named("mapCategoryToCategoryId")
-    Long mapCategoryToCategoryId(Category category) {
+    default Long mapCategoryToCategoryId(Category category) {
         return category != null ? category.getId() : null;
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Account.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Account.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(name = "accounts")
-public class Account {
+public class Account extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
@@ -11,13 +11,13 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(
         name = "bank_transactions",
         uniqueConstraints =
                 @UniqueConstraint(columnNames = {"iban", "booking_date", "purpose", "counterparty", "amount"}))
-public class BankTransaction {
+public class BankTransaction extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/model/BaseModel.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BaseModel.java
@@ -1,0 +1,38 @@
+package com.lennartmoeller.finance.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.sql.Timestamp;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@MappedSuperclass
+public abstract class BaseModel {
+
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6)")
+    private Timestamp createdAt;
+
+    @Column(
+            nullable = false,
+            columnDefinition = "TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)")
+    private Timestamp modifiedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Timestamp now = Timestamp.from(Instant.now());
+        createdAt = now;
+        modifiedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        modifiedAt = Timestamp.from(Instant.now());
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Category.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Category.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(name = "categories")
-public class Category {
+public class Category extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/model/InflationRate.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/InflationRate.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(name = "inflation_rates")
-public class InflationRate {
+public class InflationRate extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Target.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Target.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(name = "targets")
-public class Target {
+public class Target extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @Entity
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
 @Table(name = "transactions")
-public class Transaction {
+public class Transaction extends BaseModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/lennartmoeller/finance/service/CategoryService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/CategoryService.java
@@ -26,7 +26,7 @@ public class CategoryService {
     }
 
     public CategoryDTO save(CategoryDTO categoryDTO) {
-        Category category = categoryMapper.toEntity(categoryDTO);
+        Category category = categoryMapper.toEntity(categoryDTO, categoryRepository);
         Category savedCategory = categoryRepository.save(category);
         return categoryMapper.toDto(savedCategory);
     }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
@@ -3,6 +3,8 @@ package com.lennartmoeller.finance.service;
 import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.YearMonth;
 import java.util.Comparator;
@@ -19,6 +21,8 @@ public class TransactionService {
     private final CategoryService categoryService;
     private final TransactionRepository transactionRepository;
     private final TransactionMapper transactionMapper;
+    private final AccountRepository accountRepository;
+    private final CategoryRepository categoryRepository;
 
     public List<TransactionDTO> findFiltered(
             @Nullable List<Long> accountIds,
@@ -44,7 +48,7 @@ public class TransactionService {
     }
 
     public TransactionDTO save(TransactionDTO transactionDTO) {
-        Transaction transaction = transactionMapper.toEntity(transactionDTO);
+        Transaction transaction = transactionMapper.toEntity(transactionDTO, accountRepository, categoryRepository);
         Transaction savedTransaction = transactionRepository.save(transaction);
         return transactionMapper.toDto(savedTransaction);
     }

--- a/backend/src/test/java/com/lennartmoeller/finance/model/BaseModelTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/BaseModelTest.java
@@ -1,0 +1,44 @@
+package com.lennartmoeller.finance.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.lennartmoeller.finance.repository.AccountRepository;
+import java.sql.Timestamp;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+@DataJpaTest(
+        properties = {
+            "spring.jpa.hibernate.ddl-auto=create-drop",
+            "spring.jpa.properties.hibernate.hbm2ddl.import_files="
+        })
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class BaseModelTest {
+
+    private final AccountRepository accountRepository;
+
+    BaseModelTest(AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @Test
+    void testCreatedAndModifiedAreSet() {
+        Account account = new Account();
+        account.setLabel("A");
+        account.setStartBalance(0L);
+        Account saved = accountRepository.saveAndFlush(account);
+
+        assertNotNull(saved.getCreatedAt());
+        assertNotNull(saved.getModifiedAt());
+        Timestamp created = saved.getCreatedAt();
+        Timestamp modified = saved.getModifiedAt();
+
+        saved.setLabel("B");
+        Account updated = accountRepository.saveAndFlush(saved);
+
+        assertEquals(created, updated.getCreatedAt());
+        assertTrue(updated.getModifiedAt().after(modified)
+                || updated.getModifiedAt().equals(modified));
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/CategoryServiceTest.java
@@ -85,7 +85,7 @@ class CategoryServiceTest {
         Category saved = new Category();
         CategoryDTO output = new CategoryDTO();
 
-        when(categoryMapper.toEntity(input)).thenReturn(entity);
+        when(categoryMapper.toEntity(input, categoryRepository)).thenReturn(entity);
         when(categoryRepository.save(entity)).thenReturn(saved);
         when(categoryMapper.toDto(saved)).thenReturn(output);
 

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.*;
 import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -20,6 +22,8 @@ class TransactionServiceTest {
     private CategoryService categoryService;
     private TransactionRepository transactionRepository;
     private TransactionMapper transactionMapper;
+    private AccountRepository accountRepository;
+    private CategoryRepository categoryRepository;
     private TransactionService service;
 
     @BeforeEach
@@ -27,7 +31,10 @@ class TransactionServiceTest {
         categoryService = mock(CategoryService.class);
         transactionRepository = mock(TransactionRepository.class);
         transactionMapper = mock(TransactionMapper.class);
-        service = new TransactionService(categoryService, transactionRepository, transactionMapper);
+        accountRepository = mock(AccountRepository.class);
+        categoryRepository = mock(CategoryRepository.class);
+        service = new TransactionService(
+                categoryService, transactionRepository, transactionMapper, accountRepository, categoryRepository);
     }
 
     @Test
@@ -104,7 +111,8 @@ class TransactionServiceTest {
         Transaction saved = new Transaction();
         TransactionDTO dtoOut = new TransactionDTO();
 
-        when(transactionMapper.toEntity(dtoIn)).thenReturn(entity);
+        when(transactionMapper.toEntity(dtoIn, accountRepository, categoryRepository))
+                .thenReturn(entity);
         when(transactionRepository.save(entity)).thenReturn(saved);
         when(transactionMapper.toDto(saved)).thenReturn(dtoOut);
 


### PR DESCRIPTION
## Summary
- give timestamp fields DB defaults and keep lifecycle hooks
- revert test data to rely on DB defaults
- remove the timestamp repair runner and its test

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_6864d4fa3bf08324b89d6f26a6f12f4b