### PR TITLE
feat: add IBAN to Accounts

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/dto/AccountDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/AccountDTO.java
@@ -11,6 +11,7 @@ public class AccountDTO {
 
     private Long id;
     private String label;
+    private String iban;
     private Long startBalance;
     private Boolean active;
     private Boolean deposits;

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Account.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Account.java
@@ -19,6 +19,9 @@ public class Account extends BaseModel {
     @Column(nullable = false, unique = true)
     private String label;
 
+    @Column(unique = true)
+    private String iban;
+
     @Column(nullable = false)
     private Long startBalance;
 

--- a/backend/src/test/java/com/lennartmoeller/finance/dto/AccountDTOTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/dto/AccountDTOTest.java
@@ -12,12 +12,14 @@ class AccountDTOTest {
         AccountDTO dto = new AccountDTO();
         dto.setId(3L);
         dto.setLabel("Checking");
+        dto.setIban("DE123");
         dto.setStartBalance(200L);
         dto.setActive(true);
         dto.setDeposits(false);
 
         assertEquals(3L, dto.getId());
         assertEquals("Checking", dto.getLabel());
+        assertEquals("DE123", dto.getIban());
         assertEquals(200L, dto.getStartBalance());
         assertTrue(dto.getActive());
         assertFalse(dto.getDeposits());

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/AccountMapperTest.java
@@ -15,6 +15,7 @@ class AccountMapperTest {
         Account account = new Account();
         account.setId(1L);
         account.setLabel("Checking");
+        account.setIban("DE123");
         account.setStartBalance(500L);
         account.setActive(false);
         account.setDeposits(true);
@@ -23,6 +24,7 @@ class AccountMapperTest {
         assertNotNull(dto);
         assertEquals(account.getId(), dto.getId());
         assertEquals(account.getLabel(), dto.getLabel());
+        assertEquals(account.getIban(), dto.getIban());
         assertEquals(account.getStartBalance(), dto.getStartBalance());
         assertEquals(account.getActive(), dto.getActive());
         assertEquals(account.getDeposits(), dto.getDeposits());
@@ -31,6 +33,7 @@ class AccountMapperTest {
         assertNotNull(entity);
         assertEquals(account.getId(), entity.getId());
         assertEquals(account.getLabel(), entity.getLabel());
+        assertEquals(account.getIban(), entity.getIban());
         assertEquals(account.getStartBalance(), entity.getStartBalance());
         assertEquals(account.getActive(), entity.getActive());
         assertEquals(account.getDeposits(), entity.getDeposits());

--- a/backend/src/test/java/com/lennartmoeller/finance/model/AccountTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/AccountTest.java
@@ -9,6 +9,7 @@ class AccountTest {
     @Test
     void testDefaultValues() {
         Account account = new Account();
+        assertNull(account.getIban());
         assertTrue(account.getActive());
         assertFalse(account.getDeposits());
     }
@@ -17,11 +18,13 @@ class AccountTest {
     void testGettersAndSetters() {
         Account account = new Account();
         account.setLabel("Checking");
+        account.setIban("DE123");
         account.setStartBalance(1000L);
         account.setActive(false);
         account.setDeposits(true);
 
         assertEquals("Checking", account.getLabel());
+        assertEquals("DE123", account.getIban());
         assertEquals(1000L, account.getStartBalance());
         assertFalse(account.getActive());
         assertTrue(account.getDeposits());


### PR DESCRIPTION
## Summary
- Introduced a new optional “iban” column in the Account model to store account IBANs when available
- Added the corresponding “iban” property to AccountDTO so that it can be serialized in API responses

## Testing
- `cd backend && chmod +x ./mvnw`
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68662d9de4a88324b2561f0e7c93c506