### PR TITLE
feat: data field as identifying column in BankTransaction

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
@@ -13,10 +13,7 @@ import lombok.RequiredArgsConstructor;
 @Entity
 @EqualsAndHashCode(of = "id", callSuper = false)
 @RequiredArgsConstructor
-@Table(
-        name = "bank_transactions",
-        uniqueConstraints =
-                @UniqueConstraint(columnNames = {"account", "booking_date", "purpose", "counterparty", "amount"}))
+@Table(name = "bank_transactions")
 public class BankTransaction extends BaseModel {
 
     @Id
@@ -45,5 +42,6 @@ public class BankTransaction extends BaseModel {
 
     @Lob
     @Convert(converter = MapToJsonStringConverter.class)
+    @Column(unique = true)
     private Map<String, String> data = new HashMap<>();
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/BankTransactionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/BankTransactionRepository.java
@@ -1,12 +1,10 @@
 package com.lennartmoeller.finance.repository;
 
-import com.lennartmoeller.finance.model.Account;
 import com.lennartmoeller.finance.model.BankTransaction;
-import java.time.LocalDate;
+import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BankTransactionRepository extends JpaRepository<BankTransaction, Long> {
 
-    boolean existsByAccountAndBookingDateAndPurposeAndCounterpartyAndAmount(
-            Account account, LocalDate bookingDate, String purpose, String counterparty, Long amount);
+    boolean existsByData(Map<String, String> data);
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/BankCsvImportService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/BankCsvImportService.java
@@ -70,13 +70,7 @@ public class BankCsvImportService {
                         unsaved.add(dto);
                         return;
                     }
-                    boolean exists = repository.existsByAccountAndBookingDateAndPurposeAndCounterpartyAndAmount(
-                            entity.getAccount(),
-                            entity.getBookingDate(),
-                            entity.getPurpose(),
-                            entity.getCounterparty(),
-                            entity.getAmount());
-                    if (exists) {
+                    if (repository.existsByData(entity.getData())) {
                         unsaved.add(dto);
                         return;
                     }

--- a/backend/src/test/java/com/lennartmoeller/finance/service/BankCsvImportServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/BankCsvImportServiceTest.java
@@ -58,9 +58,7 @@ class BankCsvImportServiceTest {
         BankTransaction entity = new BankTransaction();
         entity.setAccount(account);
         when(mapper.toEntity(eq(dto), eq(account))).thenReturn(entity);
-        when(repository.existsByAccountAndBookingDateAndPurposeAndCounterpartyAndAmount(
-                        eq(account), any(), any(), any(), any()))
-                .thenReturn(false);
+        when(repository.existsByData(any())).thenReturn(false);
         BankTransaction saved = new BankTransaction();
         when(repository.save(entity)).thenReturn(saved);
         BankTransactionDTO resultDto = new BankTransactionDTO();
@@ -90,9 +88,7 @@ class BankCsvImportServiceTest {
         BankTransaction entity = new BankTransaction();
         entity.setAccount(account);
         when(mapper.toEntity(eq(dto), eq(account))).thenReturn(entity);
-        when(repository.existsByAccountAndBookingDateAndPurposeAndCounterpartyAndAmount(
-                        eq(account), any(), any(), any(), any()))
-                .thenReturn(true);
+        when(repository.existsByData(any())).thenReturn(true);
 
         BankTransactionImportResultDTO result = service.importCsv(BankType.ING_V1, file);
 
@@ -146,9 +142,7 @@ class BankCsvImportServiceTest {
         e2.setAccount(account);
         when(mapper.toEntity(eq(dto1), eq(account))).thenReturn(e1);
         when(mapper.toEntity(eq(dto2), eq(account))).thenReturn(e2);
-        when(repository.existsByAccountAndBookingDateAndPurposeAndCounterpartyAndAmount(
-                        eq(account), any(), any(), any(), any()))
-                .thenReturn(false);
+        when(repository.existsByData(any())).thenReturn(false);
         when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(mapper.toDto(same(e1))).thenReturn(dto1);
         when(mapper.toDto(same(e2))).thenReturn(dto2);


### PR DESCRIPTION
## Summary
- remove outdated composite unique constraint on `BankTransaction`
- rely on `@Column(unique = true)` for the `data` field
- inline repository check when filtering duplicates in `BankCsvImportService`

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_6866f1606e608324bab53ccaec5c6453