### PR TITLE
Add BankTransaction link to Transaction

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
@@ -16,4 +16,5 @@ public class TransactionDTO {
     private Long amount;
     private String description;
     private Boolean pinned;
+    private Long bankTransactionId;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
@@ -2,9 +2,11 @@ package com.lennartmoeller.finance.mapper;
 
 import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.model.BankTransaction;
 import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -18,14 +20,20 @@ import org.mapstruct.Named;
 public interface TransactionMapper {
     @Mapping(source = "account.id", target = "accountId")
     @Mapping(source = "category.id", target = "categoryId")
+    @Mapping(source = "bankTransaction.id", target = "bankTransactionId")
     TransactionDTO toDto(Transaction transaction);
 
     @Mapping(target = "account", source = "accountId", qualifiedByName = "mapAccountIdToAccount")
     @Mapping(target = "category", source = "categoryId", qualifiedByName = "mapCategoryIdToCategory")
+    @Mapping(
+            target = "bankTransaction",
+            source = "bankTransactionId",
+            qualifiedByName = "mapBankTransactionIdToBankTransaction")
     Transaction toEntity(
             TransactionDTO dto,
             @Context AccountRepository accountRepository,
-            @Context CategoryRepository categoryRepository);
+            @Context CategoryRepository categoryRepository,
+            @Context BankTransactionRepository bankTransactionRepository);
 
     @Named("mapAccountIdToAccount")
     default Account mapAccountIdToAccount(Long accountId, @Context AccountRepository repository) {
@@ -45,5 +53,16 @@ public interface TransactionMapper {
     @Named("mapCategoryToCategoryId")
     default Long mapCategoryToCategoryId(Category category) {
         return category != null ? category.getId() : null;
+    }
+
+    @Named("mapBankTransactionIdToBankTransaction")
+    default BankTransaction mapBankTransactionIdToBankTransaction(
+            Long id, @Context BankTransactionRepository repository) {
+        return id != null ? repository.findById(id).orElse(null) : null;
+    }
+
+    @Named("mapBankTransactionToBankTransactionId")
+    default Long mapBankTransactionToBankTransactionId(BankTransaction tx) {
+        return tx != null ? tx.getId() : null;
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
@@ -2,6 +2,7 @@ package com.lennartmoeller.finance.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDate;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
@@ -35,4 +36,9 @@ public class Transaction extends BaseModel {
 
     @Column(nullable = false)
     private Boolean pinned = false;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bank_transaction", unique = true)
+    @Nullable
+    private BankTransaction bankTransaction;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
@@ -4,6 +4,7 @@ import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.YearMonth;
@@ -22,6 +23,7 @@ public class TransactionService {
     private final TransactionMapper transactionMapper;
     private final AccountRepository accountRepository;
     private final CategoryRepository categoryRepository;
+    private final BankTransactionRepository bankTransactionRepository;
 
     public List<TransactionDTO> findFiltered(
             @Nullable List<Long> accountIds,
@@ -47,7 +49,8 @@ public class TransactionService {
     }
 
     public TransactionDTO save(TransactionDTO transactionDTO) {
-        Transaction transaction = transactionMapper.toEntity(transactionDTO, accountRepository, categoryRepository);
+        Transaction transaction = transactionMapper.toEntity(
+                transactionDTO, accountRepository, categoryRepository, bankTransactionRepository);
         Transaction savedTransaction = transactionRepository.save(transaction);
         return transactionMapper.toDto(savedTransaction);
     }

--- a/backend/src/test/java/com/lennartmoeller/finance/dto/TransactionDTOTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/dto/TransactionDTOTest.java
@@ -16,6 +16,8 @@ class TransactionDTOTest {
         dto.setDate(d);
         dto.setAmount(100L);
         dto.setDescription("desc");
+        dto.setPinned(true);
+        dto.setBankTransactionId(9L);
 
         assertEquals(1L, dto.getId());
         assertEquals(2L, dto.getAccountId());
@@ -23,5 +25,7 @@ class TransactionDTOTest {
         assertEquals(d, dto.getDate());
         assertEquals(100L, dto.getAmount());
         assertEquals("desc", dto.getDescription());
+        assertEquals(true, dto.getPinned());
+        assertEquals(9L, dto.getBankTransactionId());
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/model/TransactionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/TransactionTest.java
@@ -24,12 +24,17 @@ class TransactionTest {
         tx.setDate(LocalDate.of(2024, 2, 2));
         tx.setAmount(200L);
         tx.setDescription("desc");
+        BankTransaction btx = new BankTransaction();
+        tx.setBankTransaction(btx);
+        tx.setPinned(true);
 
         assertEquals(account, tx.getAccount());
         assertEquals(category, tx.getCategory());
         assertEquals(LocalDate.of(2024, 2, 2), tx.getDate());
         assertEquals(200L, tx.getAmount());
         assertEquals("desc", tx.getDescription());
+        assertSame(btx, tx.getBankTransaction());
+        assertTrue(tx.getPinned());
     }
 
     @Test

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
@@ -8,6 +8,7 @@ import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.LocalDate;
@@ -23,6 +24,7 @@ class TransactionServiceTest {
     private TransactionMapper transactionMapper;
     private AccountRepository accountRepository;
     private CategoryRepository categoryRepository;
+    private BankTransactionRepository bankTransactionRepository;
     private TransactionService service;
 
     @BeforeEach
@@ -32,8 +34,14 @@ class TransactionServiceTest {
         transactionMapper = mock(TransactionMapper.class);
         accountRepository = mock(AccountRepository.class);
         categoryRepository = mock(CategoryRepository.class);
+        bankTransactionRepository = mock(BankTransactionRepository.class);
         service = new TransactionService(
-                categoryService, transactionRepository, transactionMapper, accountRepository, categoryRepository);
+                categoryService,
+                transactionRepository,
+                transactionMapper,
+                accountRepository,
+                categoryRepository,
+                bankTransactionRepository);
     }
 
     @Test
@@ -110,7 +118,7 @@ class TransactionServiceTest {
         Transaction saved = new Transaction();
         TransactionDTO dtoOut = new TransactionDTO();
 
-        when(transactionMapper.toEntity(dtoIn, accountRepository, categoryRepository))
+        when(transactionMapper.toEntity(dtoIn, accountRepository, categoryRepository, bankTransactionRepository))
                 .thenReturn(entity);
         when(transactionRepository.save(entity)).thenReturn(saved);
         when(transactionMapper.toDto(saved)).thenReturn(dtoOut);
@@ -118,6 +126,7 @@ class TransactionServiceTest {
         TransactionDTO result = service.save(dtoIn);
 
         assertEquals(dtoOut, result);
+        verify(transactionMapper).toEntity(dtoIn, accountRepository, categoryRepository, bankTransactionRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- link transactions to imported bank transactions via a nullable one-to-one field
- expose the bank transaction ID in `TransactionDTO`
- map the new field in `TransactionMapper` and inject repository into `TransactionService`
- adjust DTOs, services and mapper tests

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_6868ec8b99608324b35c2dc6f8a17b1f