### PR TITLE
Add TransactionLinkSuggestion entity

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
@@ -1,0 +1,28 @@
+package com.lennartmoeller.finance.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@Entity
+@EqualsAndHashCode(of = "id", callSuper = false)
+@RequiredArgsConstructor
+@Table(name = "transaction_link_suggestions")
+public class TransactionLinkSuggestion extends BaseModel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bank_transaction", nullable = false)
+    private BankTransaction bankTransaction;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "transaction", nullable = false)
+    private Transaction transaction;
+
+    @Column(nullable = false)
+    private Double probability;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionLinkSuggestionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionLinkSuggestionRepository.java
@@ -1,0 +1,6 @@
+package com.lennartmoeller.finance.repository;
+
+import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionLinkSuggestionRepository extends JpaRepository<TransactionLinkSuggestion, Long> {}

--- a/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
@@ -1,0 +1,33 @@
+package com.lennartmoeller.finance.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TransactionLinkSuggestionTest {
+    @Test
+    void testGettersAndSetters() {
+        TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
+        BankTransaction btx = new BankTransaction();
+        Transaction tx = new Transaction();
+        suggestion.setBankTransaction(btx);
+        suggestion.setTransaction(tx);
+        suggestion.setProbability(0.5);
+
+        assertEquals(btx, suggestion.getBankTransaction());
+        assertEquals(tx, suggestion.getTransaction());
+        assertEquals(0.5, suggestion.getProbability());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        TransactionLinkSuggestion s1 = new TransactionLinkSuggestion();
+        s1.setId(1L);
+        TransactionLinkSuggestion s2 = new TransactionLinkSuggestion();
+        s2.setId(1L);
+        assertEquals(s1, s2);
+        assertEquals(s1.hashCode(), s2.hashCode());
+        s2.setId(2L);
+        assertNotEquals(s1, s2);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce entity for linking bank transactions with transactions
- expose repository for the new entity
- provide unit tests

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6868f55ea6248324909d2b24e1fa0598