### PR TITLE
Add endpoint for transaction link suggestions

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionController.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionController.java
@@ -1,0 +1,21 @@
+package com.lennartmoeller.finance.controller;
+
+import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
+import com.lennartmoeller.finance.service.TransactionLinkSuggestionService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/transaction-link-suggestions")
+@RequiredArgsConstructor
+public class TransactionLinkSuggestionController {
+    private final TransactionLinkSuggestionService service;
+
+    @GetMapping
+    public List<TransactionLinkSuggestionDTO> getTransactionLinkSuggestions() {
+        return service.findAll();
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
@@ -1,0 +1,15 @@
+package com.lennartmoeller.finance.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+@Setter
+public class TransactionLinkSuggestionDTO {
+    private Long id;
+    private Long bankTransactionId;
+    private Long transactionId;
+    private Double probability;
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionLinkSuggestionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionLinkSuggestionMapper.java
@@ -1,0 +1,40 @@
+package com.lennartmoeller.finance.mapper;
+
+import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE)
+public interface TransactionLinkSuggestionMapper {
+    @Mapping(source = "bankTransaction.id", target = "bankTransactionId")
+    @Mapping(source = "transaction.id", target = "transactionId")
+    TransactionLinkSuggestionDTO toDto(TransactionLinkSuggestion entity);
+
+    @Mapping(
+            target = "bankTransaction",
+            source = "bankTransactionId",
+            qualifiedByName = "mapBankTransactionIdToBankTransaction")
+    @Mapping(target = "transaction", source = "transactionId", qualifiedByName = "mapTransactionIdToTransaction")
+    TransactionLinkSuggestion toEntity(
+            TransactionLinkSuggestionDTO dto,
+            @Context BankTransactionRepository bankTransactionRepository,
+            @Context TransactionRepository transactionRepository);
+
+    @Named("mapBankTransactionIdToBankTransaction")
+    default BankTransaction mapBankTransactionIdToBankTransaction(
+            Long id, @Context BankTransactionRepository repository) {
+        return id != null ? repository.findById(id).orElse(null) : null;
+    }
+
+    @Named("mapTransactionIdToTransaction")
+    default Transaction mapTransactionIdToTransaction(Long id, @Context TransactionRepository repository) {
+        return id != null ? repository.findById(id).orElse(null) : null;
+    }
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -1,0 +1,19 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
+import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
+import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionLinkSuggestionService {
+    private final TransactionLinkSuggestionRepository repository;
+    private final TransactionLinkSuggestionMapper mapper;
+
+    public List<TransactionLinkSuggestionDTO> findAll() {
+        return repository.findAll().stream().map(mapper::toDto).toList();
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionControllerTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionControllerTest.java
@@ -1,0 +1,33 @@
+package com.lennartmoeller.finance.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
+import com.lennartmoeller.finance.service.TransactionLinkSuggestionService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransactionLinkSuggestionControllerTest {
+    private TransactionLinkSuggestionService service;
+    private TransactionLinkSuggestionController controller;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(TransactionLinkSuggestionService.class);
+        controller = new TransactionLinkSuggestionController(service);
+    }
+
+    @Test
+    void testGetTransactionLinkSuggestions() {
+        List<TransactionLinkSuggestionDTO> list =
+                List.of(new TransactionLinkSuggestionDTO(), new TransactionLinkSuggestionDTO());
+        when(service.findAll()).thenReturn(list);
+
+        List<TransactionLinkSuggestionDTO> result = controller.getTransactionLinkSuggestions();
+
+        assertEquals(list, result);
+        verify(service).findAll();
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
@@ -1,0 +1,44 @@
+package com.lennartmoeller.finance.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
+import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
+import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
+import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransactionLinkSuggestionServiceTest {
+    private TransactionLinkSuggestionRepository repository;
+    private TransactionLinkSuggestionMapper mapper;
+    private TransactionLinkSuggestionService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(TransactionLinkSuggestionRepository.class);
+        mapper = mock(TransactionLinkSuggestionMapper.class);
+        service = new TransactionLinkSuggestionService(repository, mapper);
+    }
+
+    @Test
+    void testFindAll() {
+        TransactionLinkSuggestion s1 = new TransactionLinkSuggestion();
+        TransactionLinkSuggestion s2 = new TransactionLinkSuggestion();
+        when(repository.findAll()).thenReturn(List.of(s1, s2));
+
+        TransactionLinkSuggestionDTO d1 = new TransactionLinkSuggestionDTO();
+        TransactionLinkSuggestionDTO d2 = new TransactionLinkSuggestionDTO();
+        when(mapper.toDto(any(TransactionLinkSuggestion.class))).thenReturn(d1, d2);
+
+        List<TransactionLinkSuggestionDTO> result = service.findAll();
+
+        assertEquals(2, result.size());
+        assertEquals(d1, result.getFirst());
+        assertEquals(d2, result.get(1));
+        verify(repository).findAll();
+        verify(mapper, times(2)).toDto(any(TransactionLinkSuggestion.class));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TransactionLinkSuggestionDTO`
- add mapper for suggestions
- add service and controller to expose `/api/transaction-link-suggestions`
- cover new classes with unit tests

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_6868fc730fa4832489443e252e1b0269