### PR TITLE
Remove bankTransaction from Transaction model

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionDTO.java
@@ -16,5 +16,4 @@ public class TransactionDTO {
     private Long amount;
     private String description;
     private Boolean pinned;
-    private Long bankTransactionId;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
@@ -12,4 +12,5 @@ public class TransactionLinkSuggestionDTO {
     private Long bankTransactionId;
     private Long transactionId;
     private Double probability;
+    private Boolean linked;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/mapper/TransactionMapper.java
@@ -2,11 +2,9 @@ package com.lennartmoeller.finance.mapper;
 
 import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.model.Account;
-import com.lennartmoeller.finance.model.BankTransaction;
 import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
-import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -20,19 +18,13 @@ import org.mapstruct.Named;
 public interface TransactionMapper {
     @Mapping(source = "account.id", target = "accountId")
     @Mapping(source = "category.id", target = "categoryId")
-    @Mapping(source = "bankTransaction.id", target = "bankTransactionId")
     TransactionDTO toDto(Transaction transaction);
 
     @Mapping(target = "account", source = "accountId", qualifiedByName = "mapAccountIdToAccount")
     @Mapping(target = "category", source = "categoryId", qualifiedByName = "mapCategoryIdToCategory")
-    @Mapping(
-            target = "bankTransaction",
-            source = "bankTransactionId",
-            qualifiedByName = "mapBankTransactionIdToBankTransaction")
     Transaction toEntity(
             TransactionDTO dto,
             @Context AccountRepository accountRepository,
-            @Context BankTransactionRepository bankTransactionRepository,
             @Context CategoryRepository categoryRepository);
 
     @Named("mapAccountIdToAccount")
@@ -53,16 +45,5 @@ public interface TransactionMapper {
     @Named("mapCategoryToCategoryId")
     default Long mapCategoryToCategoryId(Category category) {
         return category != null ? category.getId() : null;
-    }
-
-    @Named("mapBankTransactionIdToBankTransaction")
-    default BankTransaction mapBankTransactionIdToBankTransaction(
-            Long id, @Context BankTransactionRepository repository) {
-        return id != null ? repository.findById(id).orElse(null) : null;
-    }
-
-    @Named("mapBankTransactionToBankTransactionId")
-    default Long mapBankTransactionToBankTransactionId(BankTransaction tx) {
-        return tx != null ? tx.getId() : null;
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/Transaction.java
@@ -2,7 +2,6 @@ package com.lennartmoeller.finance.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDate;
-import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +35,4 @@ public class Transaction extends BaseModel {
 
     @Column(nullable = false)
     private Boolean pinned = false;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bank_transaction", unique = true)
-    @Nullable
-    private BankTransaction bankTransaction;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
@@ -25,4 +25,7 @@ public class TransactionLinkSuggestion extends BaseModel {
 
     @Column(nullable = false)
     private Double probability;
+
+    @Column(nullable = false)
+    private Boolean linked = false;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionService.java
@@ -4,7 +4,6 @@ import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
-import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.YearMonth;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TransactionService {
     private final AccountRepository accountRepository;
-    private final BankTransactionRepository bankTransactionRepository;
     private final CategoryRepository categoryRepository;
     private final CategoryService categoryService;
     private final TransactionMapper transactionMapper;
@@ -49,8 +47,7 @@ public class TransactionService {
     }
 
     public TransactionDTO save(TransactionDTO transactionDTO) {
-        Transaction transaction = transactionMapper.toEntity(
-                transactionDTO, accountRepository, bankTransactionRepository, categoryRepository);
+        Transaction transaction = transactionMapper.toEntity(transactionDTO, accountRepository, categoryRepository);
         Transaction savedTransaction = transactionRepository.save(transaction);
         return transactionMapper.toDto(savedTransaction);
     }

--- a/backend/src/test/java/com/lennartmoeller/finance/dto/TransactionDTOTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/dto/TransactionDTOTest.java
@@ -17,7 +17,6 @@ class TransactionDTOTest {
         dto.setAmount(100L);
         dto.setDescription("desc");
         dto.setPinned(true);
-        dto.setBankTransactionId(9L);
 
         assertEquals(1L, dto.getId());
         assertEquals(2L, dto.getAccountId());
@@ -26,6 +25,5 @@ class TransactionDTOTest {
         assertEquals(100L, dto.getAmount());
         assertEquals("desc", dto.getDescription());
         assertEquals(true, dto.getPinned());
-        assertEquals(9L, dto.getBankTransactionId());
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/mapper/TransactionMapperTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/mapper/TransactionMapperTest.java
@@ -5,11 +5,9 @@ import static org.mockito.Mockito.*;
 
 import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.model.Account;
-import com.lennartmoeller.finance.model.BankTransaction;
 import com.lennartmoeller.finance.model.Category;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
-import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import java.lang.reflect.Method;
 import java.time.LocalDate;
@@ -31,9 +29,6 @@ class TransactionMapperTest {
         tx.setDate(LocalDate.of(2024, 1, 1));
         tx.setAmount(500L);
         tx.setDescription("Desc");
-        BankTransaction btx = new BankTransaction();
-        btx.setId(7L);
-        tx.setBankTransaction(btx);
         tx.setPinned(true);
 
         TransactionMapper mapper = new TransactionMapperImpl();
@@ -45,7 +40,6 @@ class TransactionMapperTest {
         assertEquals(tx.getDate(), dto.getDate());
         assertEquals(tx.getAmount(), dto.getAmount());
         assertEquals(tx.getDescription(), dto.getDescription());
-        assertEquals(btx.getId(), dto.getBankTransactionId());
         assertEquals(true, dto.getPinned());
     }
 
@@ -58,7 +52,6 @@ class TransactionMapperTest {
         TransactionDTO dto = mapper.toDto(tx);
         assertNull(dto.getAccountId());
         assertNull(dto.getCategoryId());
-        assertNull(dto.getBankTransactionId());
         assertEquals(false, dto.getPinned());
     }
 
@@ -66,7 +59,6 @@ class TransactionMapperTest {
     void testToEntityUsesRepositories() {
         AccountRepository accRepo = mock(AccountRepository.class);
         CategoryRepository catRepo = mock(CategoryRepository.class);
-        BankTransactionRepository bankRepo = mock(BankTransactionRepository.class);
 
         Account account = new Account();
         account.setId(2L);
@@ -82,16 +74,11 @@ class TransactionMapperTest {
         dto.setId(4L);
         dto.setAccountId(2L);
         dto.setCategoryId(3L);
-        dto.setBankTransactionId(5L);
         dto.setDate(LocalDate.of(2024, 2, 2));
         dto.setAmount(600L);
         dto.setDescription("Desc");
 
-        BankTransaction btx = new BankTransaction();
-        btx.setId(5L);
-        when(bankRepo.findById(5L)).thenReturn(Optional.of(btx));
-
-        Transaction entity = mapper.toEntity(dto, accRepo, bankRepo, catRepo);
+        Transaction entity = mapper.toEntity(dto, accRepo, catRepo);
 
         assertEquals(dto.getId(), entity.getId());
         assertSame(account, entity.getAccount());
@@ -99,34 +86,29 @@ class TransactionMapperTest {
         assertEquals(dto.getDate(), entity.getDate());
         assertEquals(dto.getAmount(), entity.getAmount());
         assertEquals(dto.getDescription(), entity.getDescription());
-        assertSame(btx, entity.getBankTransaction());
         verify(accRepo).findById(2L);
         verify(catRepo).findById(3L);
-        verify(bankRepo).findById(5L);
     }
 
     @Test
     void testToEntityNullsAndMissing() {
         AccountRepository accRepo = mock(AccountRepository.class);
         CategoryRepository catRepo = mock(CategoryRepository.class);
-        BankTransactionRepository bankRepo = mock(BankTransactionRepository.class);
         when(accRepo.findById(1L)).thenReturn(Optional.empty());
         when(catRepo.findById(2L)).thenReturn(Optional.empty());
 
         TransactionMapperImpl mapper = new TransactionMapperImpl();
 
-        assertNull(mapper.toEntity(null, accRepo, bankRepo, catRepo));
+        assertNull(mapper.toEntity(null, accRepo, catRepo));
         TransactionDTO dto = new TransactionDTO();
         dto.setAccountId(1L);
         dto.setCategoryId(2L);
-        dto.setBankTransactionId(9L);
 
-        Transaction entity = mapper.toEntity(dto, accRepo, bankRepo, catRepo);
+        Transaction entity = mapper.toEntity(dto, accRepo, catRepo);
         assertNull(entity.getAccount());
         assertNull(entity.getCategory());
         verify(accRepo).findById(1L);
         verify(catRepo).findById(2L);
-        verify(bankRepo).findById(9L);
     }
 
     @Test
@@ -134,7 +116,6 @@ class TransactionMapperTest {
         TransactionMapperImpl mapper = new TransactionMapperImpl();
         AccountRepository accRepo = mock(AccountRepository.class);
         CategoryRepository catRepo = mock(CategoryRepository.class);
-        BankTransactionRepository bankRepo = mock(BankTransactionRepository.class);
 
         Account account = new Account();
         account.setId(11L);
@@ -142,9 +123,6 @@ class TransactionMapperTest {
         Category category = new Category();
         category.setId(12L);
         when(catRepo.findById(12L)).thenReturn(Optional.of(category));
-        BankTransaction bankTx = new BankTransaction();
-        bankTx.setId(13L);
-        when(bankRepo.findById(13L)).thenReturn(Optional.of(bankTx));
 
         Method idToAcc =
                 TransactionMapper.class.getDeclaredMethod("mapAccountIdToAccount", Long.class, AccountRepository.class);
@@ -167,17 +145,5 @@ class TransactionMapperTest {
         catToId.setAccessible(true);
         assertEquals(12L, catToId.invoke(mapper, category));
         assertNull(catToId.invoke(mapper, (Object) null));
-
-        Method idToBank = TransactionMapper.class.getDeclaredMethod(
-                "mapBankTransactionIdToBankTransaction", Long.class, BankTransactionRepository.class);
-        idToBank.setAccessible(true);
-        assertSame(bankTx, idToBank.invoke(mapper, 13L, bankRepo));
-        assertNull(idToBank.invoke(mapper, null, bankRepo));
-
-        Method bankToId = TransactionMapper.class.getDeclaredMethod(
-                "mapBankTransactionToBankTransactionId", BankTransaction.class);
-        bankToId.setAccessible(true);
-        assertEquals(13L, bankToId.invoke(mapper, bankTx));
-        assertNull(bankToId.invoke(mapper, (Object) null));
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
@@ -13,10 +13,12 @@ class TransactionLinkSuggestionTest {
         suggestion.setBankTransaction(btx);
         suggestion.setTransaction(tx);
         suggestion.setProbability(0.5);
+        suggestion.setLinked(true);
 
         assertEquals(btx, suggestion.getBankTransaction());
         assertEquals(tx, suggestion.getTransaction());
         assertEquals(0.5, suggestion.getProbability());
+        assertTrue(suggestion.getLinked());
     }
 
     @Test

--- a/backend/src/test/java/com/lennartmoeller/finance/model/TransactionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/TransactionTest.java
@@ -24,8 +24,6 @@ class TransactionTest {
         tx.setDate(LocalDate.of(2024, 2, 2));
         tx.setAmount(200L);
         tx.setDescription("desc");
-        BankTransaction btx = new BankTransaction();
-        tx.setBankTransaction(btx);
         tx.setPinned(true);
 
         assertEquals(account, tx.getAccount());
@@ -33,7 +31,6 @@ class TransactionTest {
         assertEquals(LocalDate.of(2024, 2, 2), tx.getDate());
         assertEquals(200L, tx.getAmount());
         assertEquals("desc", tx.getDescription());
-        assertSame(btx, tx.getBankTransaction());
         assertTrue(tx.getPinned());
     }
 

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionServiceTest.java
@@ -8,7 +8,6 @@ import com.lennartmoeller.finance.dto.TransactionDTO;
 import com.lennartmoeller.finance.mapper.TransactionMapper;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.repository.AccountRepository;
-import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.CategoryRepository;
 import com.lennartmoeller.finance.repository.TransactionRepository;
 import java.time.LocalDate;
@@ -24,24 +23,17 @@ class TransactionServiceTest {
     private TransactionMapper transactionMapper;
     private AccountRepository accountRepository;
     private CategoryRepository categoryRepository;
-    private BankTransactionRepository bankTransactionRepository;
     private TransactionService service;
 
     @BeforeEach
     void setUp() {
         accountRepository = mock(AccountRepository.class);
-        bankTransactionRepository = mock(BankTransactionRepository.class);
         categoryRepository = mock(CategoryRepository.class);
         categoryService = mock(CategoryService.class);
         transactionMapper = mock(TransactionMapper.class);
         transactionRepository = mock(TransactionRepository.class);
         service = new TransactionService(
-                accountRepository,
-                bankTransactionRepository,
-                categoryRepository,
-                categoryService,
-                transactionMapper,
-                transactionRepository);
+                accountRepository, categoryRepository, categoryService, transactionMapper, transactionRepository);
     }
 
     @Test
@@ -118,7 +110,7 @@ class TransactionServiceTest {
         Transaction saved = new Transaction();
         TransactionDTO dtoOut = new TransactionDTO();
 
-        when(transactionMapper.toEntity(dtoIn, accountRepository, bankTransactionRepository, categoryRepository))
+        when(transactionMapper.toEntity(dtoIn, accountRepository, categoryRepository))
                 .thenReturn(entity);
         when(transactionRepository.save(entity)).thenReturn(saved);
         when(transactionMapper.toDto(saved)).thenReturn(dtoOut);
@@ -126,7 +118,7 @@ class TransactionServiceTest {
         TransactionDTO result = service.save(dtoIn);
 
         assertEquals(dtoOut, result);
-        verify(transactionMapper).toEntity(dtoIn, accountRepository, bankTransactionRepository, categoryRepository);
+        verify(transactionMapper).toEntity(dtoIn, accountRepository, categoryRepository);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove bankTransaction property from Transaction entity and DTO
- mark accepted suggestions with a new `linked` flag in TransactionLinkSuggestion
- refactor TransactionMapper and TransactionService to remove bank tx dependency
- adjust tests for updated models and mappings

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_686900269ae883249802cca61e4354f9