### PR TITLE
feat: add generation of transaction link suggestions

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionController.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionController.java
@@ -5,6 +5,7 @@ import com.lennartmoeller.finance.service.TransactionLinkSuggestionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,5 +18,10 @@ public class TransactionLinkSuggestionController {
     @GetMapping
     public List<TransactionLinkSuggestionDTO> getTransactionLinkSuggestions() {
         return service.findAll();
+    }
+
+    @PostMapping("/generate")
+    public List<TransactionLinkSuggestionDTO> generateTransactionLinkSuggestions() {
+        return service.generateSuggestions();
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionLinkSuggestionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionLinkSuggestionRepository.java
@@ -1,6 +1,10 @@
 package com.lennartmoeller.finance.repository;
 
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TransactionLinkSuggestionRepository extends JpaRepository<TransactionLinkSuggestion, Long> {}
+public interface TransactionLinkSuggestionRepository extends JpaRepository<TransactionLinkSuggestion, Long> {
+    boolean existsByBankTransactionAndTransaction(BankTransaction bankTransaction, Transaction transaction);
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
@@ -1,5 +1,6 @@
 package com.lennartmoeller.finance.repository;
 
+import com.lennartmoeller.finance.model.Account;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.projection.DailyBalanceProjection;
 import com.lennartmoeller.finance.projection.MonthlyDepositsProjection;
@@ -44,4 +45,7 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
 		    GROUP BY yearMonth
 		""")
     List<MonthlyDepositsProjection> getMonthlyDeposits();
+
+    List<Transaction> findAllByAccountAndAmountAndDateBetween(
+            Account account, Long amount, java.time.LocalDate startDate, java.time.LocalDate endDate);
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/repository/TransactionRepository.java
@@ -4,6 +4,7 @@ import com.lennartmoeller.finance.model.Account;
 import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.projection.DailyBalanceProjection;
 import com.lennartmoeller.finance.projection.MonthlyDepositsProjection;
+import java.time.LocalDate;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -47,5 +48,5 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
     List<MonthlyDepositsProjection> getMonthlyDeposits();
 
     List<Transaction> findAllByAccountAndAmountAndDateBetween(
-            Account account, Long amount, java.time.LocalDate startDate, java.time.LocalDate endDate);
+            Account account, Long amount, LocalDate startDate, LocalDate endDate);
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -2,7 +2,15 @@ package com.lennartmoeller.finance.service;
 
 import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
 import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import com.lennartmoeller.finance.util.DateRange;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,8 +20,40 @@ import org.springframework.stereotype.Service;
 public class TransactionLinkSuggestionService {
     private final TransactionLinkSuggestionRepository repository;
     private final TransactionLinkSuggestionMapper mapper;
+    private final BankTransactionRepository bankTransactionRepository;
+    private final TransactionRepository transactionRepository;
 
     public List<TransactionLinkSuggestionDTO> findAll() {
         return repository.findAll().stream().map(mapper::toDto).toList();
+    }
+
+    public List<TransactionLinkSuggestionDTO> generateSuggestions() {
+        List<TransactionLinkSuggestion> savedSuggestions = new ArrayList<>();
+        List<BankTransaction> bankTransactions = bankTransactionRepository.findAll();
+        for (BankTransaction bankTransaction : bankTransactions) {
+            LocalDate date = bankTransaction.getBookingDate();
+            LocalDate start = date.minusDays(7);
+            LocalDate end = date.plusDays(7);
+            List<Transaction> matches = transactionRepository.findAllByAccountAndAmountAndDateBetween(
+                    bankTransaction.getAccount(), bankTransaction.getAmount(), start, end);
+            int candidateCount = matches.size();
+            for (Transaction transaction : matches) {
+                if (repository.existsByBankTransactionAndTransaction(bankTransaction, transaction)) {
+                    continue;
+                }
+                long daysBetween =
+                        Math.abs(new DateRange(bankTransaction.getBookingDate(), transaction.getDate()).getDays() - 1);
+                double base = 1.0 - (daysBetween / 7.0);
+                double probability = base / candidateCount;
+                TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
+                suggestion.setBankTransaction(bankTransaction);
+                suggestion.setTransaction(transaction);
+                suggestion.setProbability(probability);
+                suggestion.setLinked(false);
+                TransactionLinkSuggestion persisted = repository.save(suggestion);
+                savedSuggestions.add(persisted);
+            }
+        }
+        return savedSuggestions.stream().map(mapper::toDto).toList();
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionControllerTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/controller/TransactionLinkSuggestionControllerTest.java
@@ -30,4 +30,15 @@ class TransactionLinkSuggestionControllerTest {
         assertEquals(list, result);
         verify(service).findAll();
     }
+
+    @Test
+    void testGenerateTransactionLinkSuggestions() {
+        List<TransactionLinkSuggestionDTO> list = List.of(new TransactionLinkSuggestionDTO());
+        when(service.generateSuggestions()).thenReturn(list);
+
+        List<TransactionLinkSuggestionDTO> result = controller.generateTransactionLinkSuggestions();
+
+        assertEquals(list, result);
+        verify(service).generateSuggestions();
+    }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
@@ -5,22 +5,34 @@ import static org.mockito.Mockito.*;
 
 import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
 import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
+import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.model.Transaction;
 import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
+import com.lennartmoeller.finance.repository.TransactionRepository;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class TransactionLinkSuggestionServiceTest {
     private TransactionLinkSuggestionRepository repository;
     private TransactionLinkSuggestionMapper mapper;
+    private BankTransactionRepository bankTransactionRepository;
+    private TransactionRepository transactionRepository;
     private TransactionLinkSuggestionService service;
 
     @BeforeEach
     void setUp() {
         repository = mock(TransactionLinkSuggestionRepository.class);
         mapper = mock(TransactionLinkSuggestionMapper.class);
-        service = new TransactionLinkSuggestionService(repository, mapper);
+        bankTransactionRepository = mock(BankTransactionRepository.class);
+        transactionRepository = mock(TransactionRepository.class);
+        service = new TransactionLinkSuggestionService(
+                repository, mapper, bankTransactionRepository, transactionRepository);
     }
 
     @Test
@@ -40,5 +52,78 @@ class TransactionLinkSuggestionServiceTest {
         assertEquals(d2, result.get(1));
         verify(repository).findAll();
         verify(mapper, times(2)).toDto(any(TransactionLinkSuggestion.class));
+    }
+
+    @Test
+    void testGenerateSuggestions() {
+        Account account = new Account();
+        account.setIban("DE");
+
+        BankTransaction bank = new BankTransaction();
+        bank.setAccount(account);
+        bank.setAmount(100L);
+        bank.setBookingDate(LocalDate.of(2024, 1, 2));
+
+        Transaction t1 = new Transaction();
+        t1.setAccount(account);
+        t1.setAmount(100L);
+        t1.setDate(LocalDate.of(2024, 1, 2));
+
+        Transaction t2 = new Transaction();
+        t2.setAccount(account);
+        t2.setAmount(100L);
+        t2.setDate(LocalDate.of(2024, 1, 5));
+
+        when(bankTransactionRepository.findAll()).thenReturn(List.of(bank));
+        when(transactionRepository.findAllByAccountAndAmountAndDateBetween(
+                        account, 100L, LocalDate.of(2023, 12, 26), LocalDate.of(2024, 1, 9)))
+                .thenReturn(List.of(t1, t2));
+        when(repository.existsByBankTransactionAndTransaction(bank, t1)).thenReturn(false);
+        when(repository.existsByBankTransactionAndTransaction(bank, t2)).thenReturn(false);
+
+        ArgumentCaptor<TransactionLinkSuggestion> captor = ArgumentCaptor.forClass(TransactionLinkSuggestion.class);
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(mapper.toDto(any())).thenReturn(new TransactionLinkSuggestionDTO());
+
+        List<TransactionLinkSuggestionDTO> result = service.generateSuggestions();
+
+        assertEquals(2, result.size());
+        verify(repository, times(2)).save(captor.capture());
+
+        List<TransactionLinkSuggestion> saved = captor.getAllValues();
+        double p1 = saved.getFirst().getProbability();
+        double p2 = saved.get(1).getProbability();
+        // one probability should be 0.5 (0 days diff / 2), the other 0.2857...
+        boolean firstMatch = Math.abs(p1 - 0.5) < 1e-6 && Math.abs(p2 - (2.0 / 7)) < 1e-6;
+        boolean secondMatch = Math.abs(p2 - 0.5) < 1e-6 && Math.abs(p1 - (2.0 / 7)) < 1e-6;
+        assertEquals(true, firstMatch || secondMatch);
+    }
+
+    @Test
+    void testGenerateSuggestionsSkipsExisting() {
+        Account account = new Account();
+        account.setIban("DE");
+
+        BankTransaction bank = new BankTransaction();
+        bank.setAccount(account);
+        bank.setAmount(50L);
+        bank.setBookingDate(LocalDate.of(2024, 2, 2));
+
+        Transaction transaction = new Transaction();
+        transaction.setAccount(account);
+        transaction.setAmount(50L);
+        transaction.setDate(LocalDate.of(2024, 2, 3));
+
+        when(bankTransactionRepository.findAll()).thenReturn(List.of(bank));
+        when(transactionRepository.findAllByAccountAndAmountAndDateBetween(
+                        account, 50L, LocalDate.of(2024, 1, 26), LocalDate.of(2024, 2, 9)))
+                .thenReturn(List.of(transaction));
+        when(repository.existsByBankTransactionAndTransaction(bank, transaction))
+                .thenReturn(true);
+
+        List<TransactionLinkSuggestionDTO> result = service.generateSuggestions();
+
+        assertEquals(0, result.size());
+        verify(repository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary
- add repository helpers for suggestion matching
- implement generation logic in `TransactionLinkSuggestionService`
- expose `/generate` endpoint in controller
- test new service logic and controller endpoint

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_686904bb65688324ab7bfec7c85c4664