### PR TITLE
Add link state to suggestions

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/dto/TransactionLinkSuggestionDTO.java
@@ -1,5 +1,6 @@
 package com.lennartmoeller.finance.dto;
 
+import com.lennartmoeller.finance.model.TransactionLinkState;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -12,5 +13,5 @@ public class TransactionLinkSuggestionDTO {
     private Long bankTransactionId;
     private Long transactionId;
     private Double probability;
-    private Boolean linked;
+    private TransactionLinkState linkState;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkState.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkState.java
@@ -1,0 +1,7 @@
+package com.lennartmoeller.finance.model;
+
+public enum TransactionLinkState {
+    CONFIRMED,
+    REJECTED,
+    UNDECIDED,
+}

--- a/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/TransactionLinkSuggestion.java
@@ -28,6 +28,7 @@ public class TransactionLinkSuggestion extends BaseModel {
     @Column(nullable = false)
     private Double probability;
 
-    @Column(nullable = false)
-    private Boolean linked = false;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "link_state", nullable = false)
+    private TransactionLinkState linkState = TransactionLinkState.UNDECIDED;
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -4,6 +4,7 @@ import com.lennartmoeller.finance.dto.TransactionLinkSuggestionDTO;
 import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
 import com.lennartmoeller.finance.model.BankTransaction;
 import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.model.TransactionLinkState;
 import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
 import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
@@ -49,7 +50,7 @@ public class TransactionLinkSuggestionService {
                 suggestion.setBankTransaction(bankTransaction);
                 suggestion.setTransaction(transaction);
                 suggestion.setProbability(probability);
-                suggestion.setLinked(false);
+                suggestion.setLinkState(TransactionLinkState.UNDECIDED);
                 TransactionLinkSuggestion persisted = repository.save(suggestion);
                 savedSuggestions.add(persisted);
             }

--- a/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/model/TransactionLinkSuggestionTest.java
@@ -13,12 +13,12 @@ class TransactionLinkSuggestionTest {
         suggestion.setBankTransaction(btx);
         suggestion.setTransaction(tx);
         suggestion.setProbability(0.5);
-        suggestion.setLinked(true);
+        suggestion.setLinkState(TransactionLinkState.CONFIRMED);
 
         assertEquals(btx, suggestion.getBankTransaction());
         assertEquals(tx, suggestion.getTransaction());
         assertEquals(0.5, suggestion.getProbability());
-        assertTrue(suggestion.getLinked());
+        assertEquals(TransactionLinkState.CONFIRMED, suggestion.getLinkState());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support link state instead of boolean flag for transaction suggestions

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_686912af15748324863ec925a5ae6ed5