### PR TITLE
Fix transaction data column type

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/model/BankTransaction.java
@@ -41,6 +41,6 @@ public class BankTransaction extends BaseModel {
 
     @Lob
     @Convert(converter = MapToJsonStringConverter.class)
-    @Column(unique = true)
+    @Column(unique = true, columnDefinition = "LONGTEXT")
     private Map<String, String> data = new HashMap<>();
 }


### PR DESCRIPTION
## Summary
- configure `bank_transactions.data` column as LONGTEXT so bigger JSON payloads fit

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_686aa12f64b483249ba1b4d8e3201c45