### PR TITLE
Fix transaction link probability calculation

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -24,6 +24,8 @@ public class TransactionLinkSuggestionService {
     private final BankTransactionRepository bankTransactionRepository;
     private final TransactionRepository transactionRepository;
 
+    private static final int WINDOW_DAYS = 7;
+
     public List<TransactionLinkSuggestionDTO> findAll() {
         return repository.findAll().stream().map(mapper::toDto).toList();
     }
@@ -45,8 +47,7 @@ public class TransactionLinkSuggestionService {
         return bankTransactionList.stream()
                 .flatMap(bankTransaction -> {
                     LocalDate date = bankTransaction.getBookingDate();
-                    int windowDays = 7;
-                    DateRange range = new DateRange(date.minusDays(windowDays), date.plusDays(windowDays));
+                    DateRange range = new DateRange(date.minusDays(WINDOW_DAYS), date.plusDays(WINDOW_DAYS));
 
                     return transactionList.stream()
                             .filter(t -> t.getAccount()
@@ -58,7 +59,7 @@ public class TransactionLinkSuggestionService {
                             .map(t -> {
                                 long daysBetween = Math.abs(
                                         new DateRange(bankTransaction.getBookingDate(), t.getDate()).getDays() - 1);
-                                double probability = 1.0 - daysBetween / (2.0 * windowDays);
+                                double probability = 1.0 - daysBetween / (2.0 * WINDOW_DAYS);
                                 TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
                                 suggestion.setBankTransaction(bankTransaction);
                                 suggestion.setTransaction(t);

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -57,12 +57,15 @@ public class TransactionLinkSuggestionService {
                             .map(t -> {
                                 long daysBetween = Math.abs(
                                         new DateRange(bankTransaction.getBookingDate(), t.getDate()).getDays() - 1);
-                                double probability = 1.0 - (daysBetween / 7.0);
+                                double probability = 1.0 - (daysBetween / 7.0 / 2.0);
                                 TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
                                 suggestion.setBankTransaction(bankTransaction);
                                 suggestion.setTransaction(t);
                                 suggestion.setProbability(probability);
-                                suggestion.setLinkState(TransactionLinkState.UNDECIDED);
+                                suggestion.setLinkState(
+                                        Math.abs(probability - 1.0) < 1e-6
+                                                ? TransactionLinkState.CONFIRMED
+                                                : TransactionLinkState.UNDECIDED);
                                 return repository.save(suggestion);
                             });
                 })

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -57,13 +57,13 @@ public class TransactionLinkSuggestionService {
                             .map(t -> {
                                 long daysBetween = Math.abs(
                                         new DateRange(bankTransaction.getBookingDate(), t.getDate()).getDays() - 1);
-                                double probability = 1.0 - (daysBetween / 7.0 / 2.0);
+                                double probability = 1.0 - daysBetween / 14.0;
                                 TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
                                 suggestion.setBankTransaction(bankTransaction);
                                 suggestion.setTransaction(t);
                                 suggestion.setProbability(probability);
                                 suggestion.setLinkState(
-                                        Math.abs(probability - 1.0) < 1e-6
+                                        daysBetween == 0
                                                 ? TransactionLinkState.CONFIRMED
                                                 : TransactionLinkState.UNDECIDED);
                                 return repository.save(suggestion);

--- a/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionService.java
@@ -45,7 +45,8 @@ public class TransactionLinkSuggestionService {
         return bankTransactionList.stream()
                 .flatMap(bankTransaction -> {
                     LocalDate date = bankTransaction.getBookingDate();
-                    DateRange range = new DateRange(date.minusDays(7), date.plusDays(7));
+                    int windowDays = 7;
+                    DateRange range = new DateRange(date.minusDays(windowDays), date.plusDays(windowDays));
 
                     return transactionList.stream()
                             .filter(t -> t.getAccount()
@@ -57,13 +58,13 @@ public class TransactionLinkSuggestionService {
                             .map(t -> {
                                 long daysBetween = Math.abs(
                                         new DateRange(bankTransaction.getBookingDate(), t.getDate()).getDays() - 1);
-                                double probability = 1.0 - daysBetween / 14.0;
+                                double probability = 1.0 - daysBetween / (2.0 * windowDays);
                                 TransactionLinkSuggestion suggestion = new TransactionLinkSuggestion();
                                 suggestion.setBankTransaction(bankTransaction);
                                 suggestion.setTransaction(t);
                                 suggestion.setProbability(probability);
                                 suggestion.setLinkState(
-                                        daysBetween == 0
+                                        probability >= 1.0
                                                 ? TransactionLinkState.CONFIRMED
                                                 : TransactionLinkState.UNDECIDED);
                                 return repository.save(suggestion);

--- a/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/TransactionLinkSuggestionServiceTest.java
@@ -8,6 +8,7 @@ import com.lennartmoeller.finance.mapper.TransactionLinkSuggestionMapper;
 import com.lennartmoeller.finance.model.Account;
 import com.lennartmoeller.finance.model.BankTransaction;
 import com.lennartmoeller.finance.model.Transaction;
+import com.lennartmoeller.finance.model.TransactionLinkState;
 import com.lennartmoeller.finance.model.TransactionLinkSuggestion;
 import com.lennartmoeller.finance.repository.BankTransactionRepository;
 import com.lennartmoeller.finance.repository.TransactionLinkSuggestionRepository;
@@ -95,9 +96,15 @@ class TransactionLinkSuggestionServiceTest {
         List<TransactionLinkSuggestion> saved = captor.getAllValues();
         double p1 = saved.getFirst().getProbability();
         double p2 = saved.get(1).getProbability();
-        boolean firstMatch = Math.abs(p1 - 1.0) < 1e-6 && Math.abs(p2 - (4.0 / 7)) < 1e-6;
-        boolean secondMatch = Math.abs(p2 - 1.0) < 1e-6 && Math.abs(p1 - (4.0 / 7)) < 1e-6;
+        boolean firstMatch = Math.abs(p1 - 1.0) < 1e-6 && Math.abs(p2 - (11.0 / 14.0)) < 1e-6;
+        boolean secondMatch = Math.abs(p2 - 1.0) < 1e-6 && Math.abs(p1 - (11.0 / 14.0)) < 1e-6;
         assertEquals(true, firstMatch || secondMatch);
+
+        TransactionLinkSuggestion confirmed = saved.stream()
+                .filter(s -> Math.abs(s.getProbability() - 1.0) < 1e-6)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(TransactionLinkState.CONFIRMED, confirmed.getLinkState());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure link suggestions calculate probability using a half-week penalty
- set link state to `CONFIRMED` when a suggestion has 100% certainty
- adjust service tests to account for new logic

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_686b511739148324a3de85687087fb44