### PR TITLE
Add bank transaction CRUD endpoints

### DIFF
--- a/backend/src/main/java/com/lennartmoeller/finance/controller/BankTransactionController.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/controller/BankTransactionController.java
@@ -1,14 +1,16 @@
 package com.lennartmoeller.finance.controller;
 
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
 import com.lennartmoeller.finance.dto.BankTransactionImportResultDTO;
 import com.lennartmoeller.finance.model.BankType;
 import com.lennartmoeller.finance.service.BankCsvImportService;
+import com.lennartmoeller.finance.service.BankTransactionService;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -16,10 +18,38 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class BankTransactionController {
     private final BankCsvImportService importService;
+    private final BankTransactionService service;
 
     @PostMapping("/import")
     public BankTransactionImportResultDTO importCsv(
             @RequestParam("type") BankType type, @RequestParam("file") MultipartFile file) throws IOException {
         return importService.importCsv(type, file);
+    }
+
+    @GetMapping
+    public List<BankTransactionDTO> getBankTransactions() {
+        return service.findAll();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BankTransactionDTO> getBankTransactionById(@PathVariable Long id) {
+        return service.findById(id).map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound()
+                .build());
+    }
+
+    @PostMapping
+    public BankTransactionDTO createOrUpdateBankTransaction(@RequestBody BankTransactionDTO bankTransactionDTO) {
+        Optional<BankTransactionDTO> optional =
+                Optional.ofNullable(bankTransactionDTO.getId()).flatMap(service::findById);
+        if (optional.isEmpty()) {
+            bankTransactionDTO.setId(null);
+        }
+        return service.save(bankTransactionDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBankTransaction(@PathVariable Long id) {
+        service.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/lennartmoeller/finance/service/BankTransactionService.java
+++ b/backend/src/main/java/com/lennartmoeller/finance/service/BankTransactionService.java
@@ -1,0 +1,45 @@
+package com.lennartmoeller.finance.service;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.mapper.BankTransactionMapper;
+import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BankTransactionService {
+    private final BankTransactionRepository repository;
+    private final BankTransactionMapper mapper;
+    private final AccountRepository accountRepository;
+
+    public List<BankTransactionDTO> findAll() {
+        return repository.findAll().stream().map(mapper::toDto).toList();
+    }
+
+    public Optional<BankTransactionDTO> findById(Long id) {
+        return repository.findById(id).map(mapper::toDto);
+    }
+
+    public BankTransactionDTO save(BankTransactionDTO dto) {
+        Account account = null;
+        if (dto.getIban() != null) {
+            account = accountRepository.findAllByIbanIn(Collections.singleton(dto.getIban())).stream()
+                    .findFirst()
+                    .orElse(null);
+        }
+        BankTransaction entity = mapper.toEntity(dto, account);
+        BankTransaction saved = repository.save(entity);
+        return mapper.toDto(saved);
+    }
+
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/test/java/com/lennartmoeller/finance/controller/BankTransactionControllerTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/controller/BankTransactionControllerTest.java
@@ -7,20 +7,27 @@ import com.lennartmoeller.finance.dto.BankTransactionDTO;
 import com.lennartmoeller.finance.dto.BankTransactionImportResultDTO;
 import com.lennartmoeller.finance.model.BankType;
 import com.lennartmoeller.finance.service.BankCsvImportService;
+import com.lennartmoeller.finance.service.BankTransactionService;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
 class BankTransactionControllerTest {
-    private BankCsvImportService service;
+    private BankCsvImportService importService;
+    private BankTransactionService service;
     private BankTransactionController controller;
 
     @BeforeEach
     void setUp() {
-        service = mock(BankCsvImportService.class);
-        controller = new BankTransactionController(service);
+        importService = mock(BankCsvImportService.class);
+        service = mock(BankTransactionService.class);
+        controller = new BankTransactionController(importService, service);
     }
 
     @Test
@@ -28,12 +35,86 @@ class BankTransactionControllerTest {
         MultipartFile file = mock(MultipartFile.class);
         BankTransactionDTO dto = new BankTransactionDTO();
         BankTransactionImportResultDTO resultDto = new BankTransactionImportResultDTO(List.of(dto), List.of());
-        when(service.importCsv(BankType.ING_V1, file)).thenReturn(resultDto);
+        when(importService.importCsv(BankType.ING_V1, file)).thenReturn(resultDto);
 
         BankTransactionImportResultDTO result = controller.importCsv(BankType.ING_V1, file);
 
         assertEquals(List.of(dto), result.getSaved());
         assertTrue(result.getUnsaved().isEmpty());
-        verify(service).importCsv(BankType.ING_V1, file);
+        verify(importService).importCsv(BankType.ING_V1, file);
+    }
+
+    @Test
+    void testGetBankTransactions() {
+        List<BankTransactionDTO> list = List.of(new BankTransactionDTO());
+        when(service.findAll()).thenReturn(list);
+
+        List<BankTransactionDTO> result = controller.getBankTransactions();
+
+        assertEquals(list, result);
+        verify(service).findAll();
+    }
+
+    @Test
+    void testGetBankTransactionByIdFound() {
+        BankTransactionDTO dto = new BankTransactionDTO();
+        when(service.findById(1L)).thenReturn(Optional.of(dto));
+
+        ResponseEntity<BankTransactionDTO> response = controller.getBankTransactionById(1L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(dto, response.getBody());
+    }
+
+    @Test
+    void testGetBankTransactionByIdNotFound() {
+        when(service.findById(2L)).thenReturn(Optional.empty());
+
+        ResponseEntity<BankTransactionDTO> response = controller.getBankTransactionById(2L);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
+    void testCreateOrUpdateBankTransactionExisting() {
+        BankTransactionDTO dto = new BankTransactionDTO();
+        dto.setId(3L);
+        BankTransactionDTO saved = new BankTransactionDTO();
+
+        when(service.findById(3L)).thenReturn(Optional.of(new BankTransactionDTO()));
+        when(service.save(dto)).thenReturn(saved);
+
+        BankTransactionDTO result = controller.createOrUpdateBankTransaction(dto);
+
+        assertEquals(saved, result);
+        assertEquals(3L, dto.getId());
+        verify(service).save(dto);
+    }
+
+    @Test
+    void testCreateOrUpdateBankTransactionNew() {
+        BankTransactionDTO dto = new BankTransactionDTO();
+        dto.setId(4L);
+        BankTransactionDTO saved = new BankTransactionDTO();
+
+        when(service.findById(4L)).thenReturn(Optional.empty());
+        when(service.save(any())).thenReturn(saved);
+
+        BankTransactionDTO result = controller.createOrUpdateBankTransaction(dto);
+
+        assertEquals(saved, result);
+        ArgumentCaptor<BankTransactionDTO> captor = ArgumentCaptor.forClass(BankTransactionDTO.class);
+        verify(service).save(captor.capture());
+        assertNull(captor.getValue().getId());
+    }
+
+    @Test
+    void testDeleteBankTransaction() {
+        ResponseEntity<Void> response = controller.deleteBankTransaction(5L);
+
+        verify(service).deleteById(5L);
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+        assertNull(response.getBody());
     }
 }

--- a/backend/src/test/java/com/lennartmoeller/finance/service/BankTransactionServiceTest.java
+++ b/backend/src/test/java/com/lennartmoeller/finance/service/BankTransactionServiceTest.java
@@ -1,0 +1,91 @@
+package com.lennartmoeller.finance.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import com.lennartmoeller.finance.dto.BankTransactionDTO;
+import com.lennartmoeller.finance.mapper.BankTransactionMapper;
+import com.lennartmoeller.finance.model.Account;
+import com.lennartmoeller.finance.model.BankTransaction;
+import com.lennartmoeller.finance.repository.AccountRepository;
+import com.lennartmoeller.finance.repository.BankTransactionRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BankTransactionServiceTest {
+    private BankTransactionRepository repository;
+    private BankTransactionMapper mapper;
+    private AccountRepository accountRepository;
+    private BankTransactionService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(BankTransactionRepository.class);
+        mapper = mock(BankTransactionMapper.class);
+        accountRepository = mock(AccountRepository.class);
+        service = new BankTransactionService(repository, mapper, accountRepository);
+    }
+
+    @Test
+    void testFindAll() {
+        BankTransaction t = new BankTransaction();
+        BankTransactionDTO dto = new BankTransactionDTO();
+        when(repository.findAll()).thenReturn(List.of(t));
+        when(mapper.toDto(t)).thenReturn(dto);
+
+        List<BankTransactionDTO> result = service.findAll();
+
+        assertEquals(List.of(dto), result);
+    }
+
+    @Test
+    void testFindByIdFound() {
+        BankTransaction t = new BankTransaction();
+        BankTransactionDTO dto = new BankTransactionDTO();
+        when(repository.findById(7L)).thenReturn(Optional.of(t));
+        when(mapper.toDto(t)).thenReturn(dto);
+
+        Optional<BankTransactionDTO> result = service.findById(7L);
+
+        assertTrue(result.isPresent());
+        assertEquals(dto, result.get());
+    }
+
+    @Test
+    void testFindByIdNotFound() {
+        when(repository.findById(8L)).thenReturn(Optional.empty());
+
+        Optional<BankTransactionDTO> result = service.findById(8L);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
+    void testSave() {
+        BankTransactionDTO dtoIn = new BankTransactionDTO();
+        dtoIn.setIban("DE");
+        BankTransaction entity = new BankTransaction();
+        BankTransaction saved = new BankTransaction();
+        BankTransactionDTO dtoOut = new BankTransactionDTO();
+        Account account = new Account();
+        when(accountRepository.findAllByIbanIn(Collections.singleton("DE"))).thenReturn(List.of(account));
+        when(mapper.toEntity(dtoIn, account)).thenReturn(entity);
+        when(repository.save(entity)).thenReturn(saved);
+        when(mapper.toDto(saved)).thenReturn(dtoOut);
+
+        BankTransactionDTO result = service.save(dtoIn);
+
+        assertEquals(dtoOut, result);
+    }
+
+    @Test
+    void testDeleteById() {
+        service.deleteById(11L);
+        verify(repository).deleteById(11L);
+    }
+}


### PR DESCRIPTION
## Summary
- create `BankTransactionService` for persisting and fetching bank transactions
- extend `BankTransactionController` with CRUD endpoints
- cover controller and service with unit tests

## Testing
- `./mvnw spotless:apply`
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_686b535add8083249465017c0714e1eb